### PR TITLE
ci: export cargo path in the build script ( PROOF-624 )

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eou pipefail
 
+export PATH=$PATH:/root/.cargo/bin/
+
+rustup default stable
+
 NEW_VERSION=$1
 
 if ! [[ ${NEW_VERSION} =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]


### PR DESCRIPTION
# Rationale for this change

This change ensures that the Cargo command is found and accessible during the build script execution by exporting its path.

# What changes are included in this PR?

* Exports the Cargo path in the build script.

# Are these changes tested?

Testing is conducted only locally.