### PR TITLE
chore: update blitzar logo link ( PROOF-679 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <img
  alt="blitzar logo"
  width="200px"
- src="https://github.com/spaceandtimelabs/blitzar-rs/blob/assets/logo.png"/>
+ src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png"/>
 </p>
 
   <a href="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml">


### PR DESCRIPTION
# Rationale for this change
The blitzar logo is broken in the crates.io README. To fix this issue we need to update the link to point to `raw.githubusercontent`. 
![image](https://github.com/spaceandtimelabs/blitzar-rs/assets/6509385/b3876ed9-9081-40b3-874f-d4a3f3e71b94)

# What changes are included in this PR?
- blitzar logo link updated in README

# Are these changes tested?
- The changes have been tested in VSCode. Not on crates.io.
