### PR TITLE
ci: bump blitzar-sys version ( PROOF-681 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 
 [dependencies]
 ark-ff = { version = "0.4.0", optional = true }
-blitzar-sys = { version = "0.2.0" }
+blitzar-sys = { version = "0.5.1" }
 curve25519-dalek = { version = "3", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }


### PR DESCRIPTION
# Rationale for this change
`libblitzar.so` was failing to load in some environments because the `libm` wasn't linked in `blitzar-sys` versions < `0.5.1`.  See https://github.com/spaceandtimelabs/blitzar/pull/26 for the fix. We need to bump `blitzar-sys` to version `0.5.1` to allow CI to run.

# What changes are included in this PR?
- Bump blitzar-sys to `0.5.2`

# Are these changes tested?
Yes, by building and pushing to CI.
