### PR TITLE
refactor!: update api function signatures to match blitzar-sys ( PROOF-701 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 
 [dependencies]
 ark-ff = { version = "0.4.0", optional = true }
-blitzar-sys = { version = "0.5.1" }
+blitzar-sys = { version = "1.0.0" }
 curve25519-dalek = { version = "3", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -48,12 +48,12 @@ pub fn compute_commitments(
     let sxt_descriptors: Vec<blitzar_sys::sxt_sequence_descriptor> =
         data.iter().map(Into::into).collect();
 
-    let sxt_compressed_ristretto =
-        commitments.as_mut_ptr() as *mut blitzar_sys::sxt_compressed_ristretto;
+    let sxt_ristretto255_compressed =
+        commitments.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255_compressed;
 
     unsafe {
-        blitzar_sys::sxt_compute_pedersen_commitments(
-            sxt_compressed_ristretto,
+        blitzar_sys::sxt_curve25519_compute_pedersen_commitments(
+            sxt_ristretto255_compressed,
             sxt_descriptors.len() as u32,
             sxt_descriptors.as_ptr(),
             offset_generators,
@@ -95,14 +95,14 @@ pub fn compute_commitments_with_generators(
         })
         .collect();
 
-    let sxt_ristretto_generators = generators.as_ptr() as *const blitzar_sys::sxt_ristretto;
+    let sxt_ristretto_generators = generators.as_ptr() as *const blitzar_sys::sxt_ristretto255;
 
-    let sxt_compressed_ristretto =
-        commitments.as_mut_ptr() as *mut blitzar_sys::sxt_compressed_ristretto;
+    let sxt_ristretto255_compressed =
+        commitments.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255_compressed;
 
     unsafe {
-        blitzar_sys::sxt_compute_pedersen_commitments_with_generators(
-            sxt_compressed_ristretto,
+        blitzar_sys::sxt_curve25519_compute_pedersen_commitments_with_generators(
+            sxt_ristretto255_compressed,
             sxt_descriptors.len() as u32,
             sxt_descriptors.as_ptr(),
             sxt_ristretto_generators,

--- a/src/compute/generators.rs
+++ b/src/compute/generators.rs
@@ -27,7 +27,8 @@ pub fn get_generators(generators: &mut [RistrettoPoint], offset_generators: u64)
     init_backend();
 
     unsafe {
-        let sxt_ristretto_generators = generators.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255;
+        let sxt_ristretto_generators =
+            generators.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255;
 
         let ret_get_generators = blitzar_sys::sxt_ristretto255_get_generators(
             sxt_ristretto_generators,

--- a/src/compute/generators.rs
+++ b/src/compute/generators.rs
@@ -27,9 +27,9 @@ pub fn get_generators(generators: &mut [RistrettoPoint], offset_generators: u64)
     init_backend();
 
     unsafe {
-        let sxt_ristretto_generators = generators.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto;
+        let sxt_ristretto_generators = generators.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255;
 
-        let ret_get_generators = blitzar_sys::sxt_get_generators(
+        let ret_get_generators = blitzar_sys::sxt_ristretto255_get_generators(
             sxt_ristretto_generators,
             generators.len() as u64,
             offset_generators,
@@ -54,9 +54,9 @@ pub fn get_one_commit(n: u64) -> RistrettoPoint {
 
     unsafe {
         let mut one_commit: MaybeUninit<RistrettoPoint> = MaybeUninit::uninit();
-        let one_commit_ptr = one_commit.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto;
+        let one_commit_ptr = one_commit.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255;
 
-        let ret_get_one_commit = blitzar_sys::sxt_get_one_commit(one_commit_ptr, n);
+        let ret_get_one_commit = blitzar_sys::sxt_curve25519_get_one_commit(one_commit_ptr, n);
 
         if ret_get_one_commit != 0 {
             panic!("Error during get_one_commit call");

--- a/src/proof/inner_product.rs
+++ b/src/proof/inner_product.rs
@@ -129,15 +129,15 @@ impl InnerProductProof {
             vec![CompressedRistretto::default(); ceil_lg2_n];
 
         unsafe {
-            let a = a.as_ptr() as *const blitzar_sys::sxt_scalar;
-            let b = b.as_ptr() as *const blitzar_sys::sxt_scalar;
+            let a = a.as_ptr() as *const blitzar_sys::sxt_curve25519_scalar;
+            let b = b.as_ptr() as *const blitzar_sys::sxt_curve25519_scalar;
             let transcript = transcript as *mut Transcript as *mut blitzar_sys::sxt_transcript;
 
-            let ap_value = &mut ap_value as *mut Scalar as *mut blitzar_sys::sxt_scalar;
-            let l_vector = l_vector.as_mut_ptr() as *mut blitzar_sys::sxt_compressed_ristretto;
-            let r_vector = r_vector.as_mut_ptr() as *mut blitzar_sys::sxt_compressed_ristretto;
+            let ap_value = &mut ap_value as *mut Scalar as *mut blitzar_sys::sxt_curve25519_scalar;
+            let l_vector = l_vector.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255_compressed;
+            let r_vector = r_vector.as_mut_ptr() as *mut blitzar_sys::sxt_ristretto255_compressed;
 
-            blitzar_sys::sxt_prove_inner_product(
+            blitzar_sys::sxt_curve25519_prove_inner_product(
                 l_vector,
                 r_vector,
                 ap_value,
@@ -200,15 +200,15 @@ impl InnerProductProof {
         }
 
         let transcript = transcript as *mut Transcript as *mut blitzar_sys::sxt_transcript;
-        let b = b.as_ptr() as *const blitzar_sys::sxt_scalar;
-        let product = product as *const Scalar as *const blitzar_sys::sxt_scalar;
-        let a_commit = a_commit as *const RistrettoPoint as *const blitzar_sys::sxt_ristretto;
-        let ap_value = &self.ap_value as *const Scalar as *const blitzar_sys::sxt_scalar;
-        let l_vector = self.l_vector.as_ptr() as *const blitzar_sys::sxt_compressed_ristretto;
-        let r_vector = self.r_vector.as_ptr() as *const blitzar_sys::sxt_compressed_ristretto;
+        let b = b.as_ptr() as *const blitzar_sys::sxt_curve25519_scalar;
+        let product = product as *const Scalar as *const blitzar_sys::sxt_curve25519_scalar;
+        let a_commit = a_commit as *const RistrettoPoint as *const blitzar_sys::sxt_ristretto255;
+        let ap_value = &self.ap_value as *const Scalar as *const blitzar_sys::sxt_curve25519_scalar;
+        let l_vector = self.l_vector.as_ptr() as *const blitzar_sys::sxt_ristretto255_compressed;
+        let r_vector = self.r_vector.as_ptr() as *const blitzar_sys::sxt_ristretto255_compressed;
 
         unsafe {
-            let ret = blitzar_sys::sxt_verify_inner_product(
+            let ret = blitzar_sys::sxt_curve25519_verify_inner_product(
                 transcript,
                 n as u64,
                 generators_offset,


### PR DESCRIPTION
# Rationale for this change
The blitzar API is changing it's function signatures to support multiple curves. This requires the blitzar-rs project to update it's API calls.

# What changes are included in this PR?
- API calls to `blitzar-sys` are updated to match the API changes in https://github.com/spaceandtimelabs/blitzar/pull/28
- `blitzar-rs` version bumped to match API changes.

# Are these changes tested?
Yes.