### PR TITLE
feat: expose bls12-381 G1 curve commitments ( PROOF-667 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0", optional = true }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
-blitzar-sys = { version = "1.3.0" }
+blitzar-sys = { version = "1.3.3" }
 curve25519-dalek = { version = "3", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,12 @@ exclude = [
 ]
 
 [dependencies]
+ark-bls12-381 = { version = "0.4.0" }
+ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0", optional = true }
-blitzar-sys = { version = "1.0.0" }
+ark-serialize = { version = "0.4.2" }
+ark-std = { version = "0.4.0" }
+blitzar-sys = { version = "1.3.0" }
 curve25519-dalek = { version = "3", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -111,6 +111,10 @@ pub fn compute_commitments_with_generators(
     }
 }
 
+/// The documentation linked here is related to curve25519.
+/// The doc tag does not seem to be working as expected. When the doc tag issue
+/// is sorted out, documentation for the bls12-381 G1 commitment computation
+/// will be created and linked below.
 #[doc = include_str!("../../docs/commitments/compute_commitments_with_generators.md")]
 ///
 ///# Example 1 - Pass generators to Commitment Computation

--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -15,7 +15,6 @@
 use super::backend::init_backend;
 use crate::sequence::Sequence;
 use ark_bls12_381::G1Affine;
-use ark_ec::AffineRepr;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 
 #[doc = include_str!("../../docs/commitments/compute_commitments.md")]
@@ -141,15 +140,7 @@ pub fn compute_bls12_381_g1_commitments_with_generators(
         })
         .collect();
 
-    // Convert to G1Projective elements. This section can be deleted
-    // after Blitzar accepts G1Affine elements.
-    let mut generators_p2 = vec![G1Affine::identity().into_group(); generators.len()];
-    for g in 0..generators.len() {
-        generators_p2[g] = generators[g].into_group();
-    }
-
-    let sxt_bls12_381_g1_generators =
-        generators_p2.as_ptr() as *const blitzar_sys::sxt_bls12_381_g1;
+    let sxt_bls12_381_g1_generators = generators.as_ptr() as *const blitzar_sys::sxt_bls12_381_g1;
 
     let sxt_bls12_381_g1_compressed =
         commitments.as_mut_ptr() as *mut blitzar_sys::sxt_bls12_381_g1_compressed;

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -483,8 +483,8 @@ fn sending_generators_to_gpu_produces_correct_bls12_381_g1_commitment_results() 
 
     // convert data to scalar
     let mut scalar_data: Vec<Fr> = Vec::new();
-    for i in 0..data.len() {
-        scalar_data.push(Fr::try_from(data[i]).unwrap());
+    for d in &data {
+        scalar_data.push(Fr::try_from(*d).unwrap());
     }
 
     // compute msm in Arkworks

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -19,7 +19,8 @@ pub use backend::{init_backend, init_backend_with_config, BackendConfig};
 
 mod commitments;
 pub use commitments::{
-    compute_commitments, compute_commitments_with_generators, update_commitments,
+    compute_bls12_381_g1_commitments_with_generators, compute_commitments,
+    compute_commitments_with_generators, update_commitments,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
# Rationale for this change
In order to expose commitment computation with bls12-381 elements, `blitzar-rs` needs to implement a method in the commitments module. This PR does that work.

Notes for follow up work. 
1. The function names related to the previous curve25519 methods should be updated to support multiple curves. That work is outlined in [PROOF-709](https://space-and-time.atlassian.net/browse/PROOF-709).
2. The `doc` tag is not behaving as expected. A bug has been entered to investigate. See [PROOF-708](https://space-and-time.atlassian.net/browse/PROOF-708).
3. Documentation needs to be created for `compute_bls12_381_g1_commitments_with_generators`. See [PROOF-710](https://space-and-time.atlassian.net/browse/PROOF-710).

# What changes are included in this PR?
- `compute_bls12_381_g1_commitments_with_generators` is added to the commitments module.
- The `blitzar-sys` version is bumped to `1.3.3`.
- Arkworks dependencies are added to support the new function.

# Are these changes tested?
Yes. 

Note, scalar elements for the bls12-381 curve are in Montgomery form. A test similar to `sending_generators_and_scalars_to_gpu_produces_correct_commitment_results` was not written at this time. The `.into()` method needs implement a method to convert `[Fp<MontBackend<T, N>, N>]` to `BigInt<N>` in order to pass the correct values to the `Sequence` parameter. The Sequence module does have an [optional BigInt `From` implementation](https://github.com/spaceandtimelabs/blitzar-rs/blob/f5916ddd306aa0d042b198b51b06e80d96927a2a/src/sequence/mod.rs#L175-L180).

[PROOF-709]: https://space-and-time.atlassian.net/browse/PROOF-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROOF-708]: https://space-and-time.atlassian.net/browse/PROOF-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROOF-710]: https://space-and-time.atlassian.net/browse/PROOF-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ