### PR TITLE
ci: add dark Blitzar logo ( PROOF-680 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
   <h1 align="center">Blitzar Crate</h1>
 
 <p align="center">
-<img
- alt="blitzar logo"
- width="200px"
- src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png"/>
-</p>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png">
+    <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
+    <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
+  </picture>
 
   <a href="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml">
     <img alt="Build State" src="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml/badge.svg">

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <div align="center">
   <h1 align="center">Blitzar Crate</h1>
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png">
-    <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
-    <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
-  </picture>
+<picture>
+  <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png">
+  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
+  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
+</picture>
 
+<p align="center">
   <a href="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml">
     <img alt="Build State" src="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml/badge.svg">
   </a>

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png">
-  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
-  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark.png">
+  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
+  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
 </picture>
 
 <p align="center">


### PR DESCRIPTION
# Rationale for this change
The text on the Blitzar logo does not appear on light backgrounds. 
![image](https://github.com/spaceandtimelabs/blitzar-rs/assets/6509385/063ba595-4a2f-42e1-901d-756edf68ca9f)
This PR adds a logo that can be displayed on light backgrounds and updates the HTML to detect if the color scheme is light or dark.

# What changes are included in this PR?
- A new dark logo is added to the `blitzar-rs/assets` branch.
- The image link is updated to default to the dark logo.
- A `<picture>` tag is added to detect dark/light color schemes in Github's markdown following [this post](https://www.stefanjudis.com/notes/how-to-define-dark-light-mode-images-in-github-markdown/).

# Are these changes tested?
Yes, on Github and with VSCode's markdown viewer. The changes have not been tested on crates.io.

Screen shots from the Github test are below.
![image](https://github.com/spaceandtimelabs/blitzar-rs/assets/6509385/b82f559d-bc53-4754-9010-b53e3ce07591)