### PR TITLE
fix: bls12_381 G1 should allow commitment computation of more than one sequence ( PROOF-667 )

### DIFF
--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -127,7 +127,7 @@ pub fn compute_commitments_with_generators(
 #[doc = include_str!("../../examples/pass_generators_and_scalars_to_commitment.rs")]
 ///```
 pub fn compute_bls12_381_g1_commitments_with_generators(
-    commitments: &mut [u8; 48],
+    commitments: &mut [[u8; 48]],
     data: &[Sequence],
     generators: &[G1Affine],
 ) {

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -476,7 +476,7 @@ fn sending_generators_to_gpu_produces_correct_bls12_381_g1_commitment_results() 
 
     // compute commitment in Blitzar
     compute_bls12_381_g1_commitments_with_generators(
-        &mut commitments[0],
+        &mut commitments,
         &[(&data).into()],
         &generator_points,
     );


### PR DESCRIPTION
# Rationale for this change
The commitment parameter to `compute_bls12_381_g1_commitments_with_generators` was a reference to a single 48 byte array. To allow computation over multiple sequences, the commitment parameter should be a reference to an array of 48 byte arrays.

# What changes are included in this PR?
- The commitment parameter in `compute_bls12_381_g1_commitments_with_generators` is updated from `&mut [u8; 48]` to `&mut [[u8; 48]]` to allow commitment computation over multiple sequences.

# Are these changes tested?
Yes