### PR TITLE
chore: update logo url ( PROOF-680 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   <h1 align="center">Blitzar Crate</h1>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png">
-  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
-  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
+  <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_background.png">
+  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_light_background.png">
+  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_light_background.png">
 </picture>
 
 <p align="center">


### PR DESCRIPTION
# Rationale for this change
The Blitzar logo was updated right after the previous logo update. This PR updated the logo's URL.

# What changes are included in this PR?
- The URL is updated to the new logo for light and dark backgrounds.

# Are these changes tested?
Yes, on Github and VSCode.
