### PR TITLE
ci: bump blitzar-sys crate version to 1.10.0 ( PROOF-752 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0", optional = true }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
-blitzar-sys = { version = "1.3.3" }
+blitzar-sys = { version = "1.10.0" }
 curve25519-dalek = { version = "3", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }


### PR DESCRIPTION
# Rationale for this change
Bump the blitzar-sys crate version to 1.10.0 in blitzar crate.

# What changes are included in this PR?
- blitzar-sys version is bumped to 1.10.0.

# Are these changes tested?
Yes