### PR TITLE
build!: update curve25519-dalek to version 4 ( PROOF-768 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ark-ff = { version = "0.4.0", optional = true }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
 blitzar-sys = { version = "1.15.1" }
-curve25519-dalek = { version = "4", features = ["serde", "rand_core"] }
+curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
@@ -28,6 +28,7 @@ tracing = { version = "0.1.36" }
 # this sections is shared by tests, benchmarks, and examples
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
+curve25519-dalek = { version = "4", features = ["rand_core"] }
 rand = "0.8"
 rand_core = "0.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ark-ff = { version = "0.4.0", optional = true }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
 blitzar-sys = { version = "1.15.1" }
-curve25519-dalek = { version = "3", features = ["serde"] }
+curve25519-dalek = { version = "4", features = ["serde", "rand_core"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
@@ -28,8 +28,8 @@ tracing = { version = "0.1.36" }
 # this sections is shared by tests, benchmarks, and examples
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
-rand = "0.7"
-rand_core = "0.5"
+rand = "0.8"
+rand_core = "0.6"
 
 [[bench]]
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rand_core = "0.6"
 [[bench]]
 harness = false
 name = "blitzar_benchmarks"
+required-features = ["rand_core"]
 
 [features]
 arkworks = ["dep:ark-ff"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ rand_core = "0.6"
 [[bench]]
 harness = false
 name = "blitzar_benchmarks"
-required-features = ["rand_core"]
 
 [features]
 arkworks = ["dep:ark-ff"]

--- a/benches/blitzar_benchmarks.rs
+++ b/benches/blitzar_benchmarks.rs
@@ -48,7 +48,7 @@ mod blitzar_benches {
     fn construct_generators(n: usize) -> Vec<RistrettoPoint> {
         let mut rng = thread_rng();
         (0..n)
-            .map(|_| (&Scalar::random(&mut rng) * &constants::RISTRETTO_BASEPOINT_TABLE))
+            .map(|_| (&Scalar::random(&mut rng) * constants::RISTRETTO_BASEPOINT_TABLE))
             .collect()
     }
 

--- a/examples/simple_scalars_commitment.rs
+++ b/examples/simple_scalars_commitment.rs
@@ -28,15 +28,15 @@ fn main() {
     //
     /////////////////////////////////////////////
     let mut data: Vec<Scalar> = vec![
-        Scalar::zero(),
-        Scalar::one(),
-        Scalar::zero(),
+        Scalar::ZERO,
+        Scalar::ONE,
+        Scalar::ZERO,
         Scalar::from_bytes_mod_order([4; 32]),
     ];
 
     // data[2] = 2000 as 256-bits
     for _i in 0..2000 {
-        data[2] += Scalar::one();
+        data[2] += Scalar::ONE;
     }
 
     /////////////////////////////////////////////

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -142,21 +142,21 @@ fn we_can_update_multiple_commitments() {
 fn compute_commitments_with_scalars_works() {
     // generate input table
     let offset_generators = 0_u64;
-    let mut data: Vec<Scalar> = vec![Scalar::zero(); 4];
+    let mut data: Vec<Scalar> = vec![Scalar::ZERO; 4];
     let mut generators = vec![RistrettoPoint::default(); data.len()];
     get_generators(&mut generators, offset_generators);
 
     for _i in 0..2000 {
-        data[0] += Scalar::one();
+        data[0] += Scalar::ONE;
     }
     for _i in 0..7500 {
-        data[1] += Scalar::one();
+        data[1] += Scalar::ONE;
     }
     for _i in 0..5000 {
-        data[2] += Scalar::one();
+        data[2] += Scalar::ONE;
     }
     for _i in 0..1500 {
-        data[3] += Scalar::one();
+        data[3] += Scalar::ONE;
     }
 
     let mut commitments = vec![CompressedRistretto::default(); 1];


### PR DESCRIPTION
# Rationale for this change
Dependabot suggested the proofs project update curve25519-dalek from version 3 to 4. [See here](https://github.com/spaceandtimelabs/proofs/pull/426). That change would need to originate from blitzar-rs first. This PR does the work to update curve25519-dalek.

# What changes are included in this PR?
- curve25519-dalek is updated from version 3 to 4.
- rand is updated from version 0.7 to 0.8
- rand_core is updated from version 0.5 to 0.6
- rand_core is made a feature of curve25519-dalek
- Breaking changes from the curve25519-dalek crate are incorporated

# Are these changes tested?
Yes
