### PR TITLE
ci: bump blitzar-sys to version 1.15.1 ( PROOF-769 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0", optional = true }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
-blitzar-sys = { version = "1.10.0" }
+blitzar-sys = { version = "1.15.1" }
 curve25519-dalek = { version = "3", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }


### PR DESCRIPTION
# Rationale for this change
Bump the `blitzar-sys` version to `1.15.1` to incorporate a bucket method fix. [See commit](https://github.com/spaceandtimelabs/blitzar/commit/134c0c0dc55cfe5fdc4c7284345dcc178d05be41).

# What changes are included in this PR?
- `blitzar-sys` is bumped from version `1.10.0` to `1.15.1`.

# Are these changes tested?
Yes
