### PR TITLE
refactor!: update function names to support multiple curves (PROOF-709)

### DIFF
--- a/benches/blitzar_benchmarks.rs
+++ b/benches/blitzar_benchmarks.rs
@@ -83,13 +83,13 @@ mod blitzar_benches {
             group.bench_function(
                 &without_generators_label,
                 |b: &mut criterion::Bencher<'_>| {
-                    b.iter(|| compute_commitments(&mut commitments, &table, 0_u64))
+                    b.iter(|| compute_curve25519_commitments(&mut commitments, &table, 0_u64))
                 },
             );
 
             group.bench_function(&with_generators_label, |b| {
                 b.iter(|| {
-                    compute_commitments_with_generators(&mut commitments, &table, &generators)
+                    compute_curve25519_commitments_with_generators(&mut commitments, &table, &generators)
                 })
             });
         } else {
@@ -97,12 +97,12 @@ mod blitzar_benches {
             let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
 
             group.bench_function(&without_generators_label, |b| {
-                b.iter(|| compute_commitments(&mut commitments, &table, 0_u64))
+                b.iter(|| compute_curve25519_commitments(&mut commitments, &table, 0_u64))
             });
 
             group.bench_function(&with_generators_label, |b| {
                 b.iter(|| {
-                    compute_commitments_with_generators(&mut commitments, &table, &generators)
+                    compute_curve25519_commitments_with_generators(&mut commitments, &table, &generators)
                 })
             });
         }

--- a/benches/blitzar_benchmarks.rs
+++ b/benches/blitzar_benchmarks.rs
@@ -89,7 +89,11 @@ mod blitzar_benches {
 
             group.bench_function(&with_generators_label, |b| {
                 b.iter(|| {
-                    compute_curve25519_commitments_with_generators(&mut commitments, &table, &generators)
+                    compute_curve25519_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
                 })
             });
         } else {
@@ -102,7 +106,11 @@ mod blitzar_benches {
 
             group.bench_function(&with_generators_label, |b| {
                 b.iter(|| {
-                    compute_curve25519_commitments_with_generators(&mut commitments, &table, &generators)
+                    compute_curve25519_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
                 })
             });
         }

--- a/docs/commitments/compute_curve25519_commitments.md
+++ b/docs/commitments/compute_curve25519_commitments.md
@@ -41,24 +41,21 @@ let M_j = [
 ];
 ```
 
-This message M_j cannot be decrypted from C_j. The curve point C_j
-is generated in a unique way using M_j and a
-set of 1280-bit curve25519 points G_i, called row generators.
-Although our GPU code uses 1280-bit generators during the scalar 
-multiplication, these generators are passed as 256-bit Ristretto points
-and only converted to 1280-bit points inside the GPU/CPU.
-The total number of generators used to compute C_j is equal to 
-the number of `num_rows` in the data\[j] sequence. The following formula
+This message M_j cannot be decrypted from C_j. The curve point C_j is generated in a unique way using M_j and a
+set of random 1280-bit curve25519 points G_{i + offset_generators}, called row generators. The total number of generators used to compute C_j is equal to the number of `num_rows` in the data\[j] sequence. To access those generators, use the [get_curve25519_generators] function.
+
+
+The following formula
 is specified to obtain the C_j commitment when the input table is a 
 [crate::sequence::Sequence] view:
 
 ```text
 let C_j_temp = 0; // this is a 1280-bit curve25519 point
 
-for j in 0..num_rows {
-    let G_i = generators[j].decompress(); // we decompress to convert 256-bit to 1280-bit points
+for i in 0..num_rows {
+    let G_{i + offset_generators} = generators[i + offset_generators].decompress(); // we decompress to convert 256-bit to 1280-bit points
     let curr_data_ji = data[j].data_slice[i*el_size:(i + 1)*el_size];
-    C_j_temp = C_j_temp + curr_data_ji * G_i;
+    C_j_temp = C_j_temp + curr_data_ji * G_{i + offset_generators};
 }
 
 let C_j = convert_to_ristretto(C_j_temp); // this is a 256-bit Ristretto point
@@ -69,10 +66,10 @@ When we have a [curve25519_dalek::scalar::Scalar] view for the input table, we u
 ```text
 let C_j_temp = 0; // this is a 1280-bit curve25519 point
 
-for j in 0..num_rows {
-    let G_i = get_random_ristretto_point(j);
+for i in 0..num_rows {
+    let G_{i + offset_generators} = generators[i + offset_generators].decompress();
     let curr_data_ji = data[j][i];
-    C_j_temp = C_j_temp + curr_data_ji * G_i;
+    C_j_temp = C_j_temp + curr_data_ji * G_{i + offset_generators};
 }
 
 let C_j = convert_to_ristretto(C_j_temp); // this is a 256-bit Ristretto point
@@ -80,18 +77,18 @@ let C_j = convert_to_ristretto(C_j_temp); // this is a 256-bit Ristretto point
 
 Ps: the above is only illustrative code. It will not compile.
 
-Here `curr_data_ji` are simply 256-bit scalars, C_j_temp and G_i are
+Here `curr_data_ji` are simply 256-bit scalars, C_j_temp and G_{i + offset_generators} are
 1280-bit curve25519 points and C_j is a 256-bit Ristretto point.
 
-Given M_j and G_i, it is easy to verify that the Pedersen
+Given M_j and G_{i + offset_generators}, it is easy to verify that the Pedersen
 commitment C_j is the correctly generated output. However,
-the Pedersen commitment generated from M_j and G_i is cryptographically
+the Pedersen commitment generated from M_j and G_{i + offset_generators} is cryptographically
 binded to the message M_j because finding alternative inputs M_j* and 
-G_i* for which the Pedersen commitment generates the same point C_j
+G_{i + offset_generators}* for which the Pedersen commitment generates the same point C_j
 requires an infeasible amount of computation.
 
-To guarantee proper execution, so that the backend is correctly set,
-this `compute_commitments` always calls the `init_backend()` function.
+To guarantee proper execution so that the backend is correctly set,
+this `compute_curve25519_commitments` always calls the `init_backend()` function.
 
 Portions of this documentation were extracted from
 [here](findora.org/faq/crypto/pedersen-commitment-with-elliptic-curves/)
@@ -103,8 +100,8 @@ Portions of this documentation were extracted from
                you need to guarantee that this slice captures exactly
                data.len() element positions.
 
-* `data` - A generic sliced view T. Currently, we support
-        two different types of slices. First, is a slice view of a [crate::sequence::Sequence], 
+* `data` - A generic slice view T. Currently, we support
+        two different types of slices. First, a slice view of a [crate::sequence::Sequence], 
         which captures the slices of contiguous u8 memory elements.
         In this case, you need to guarantee that the contiguous u8 slice view
         captures the correct amount of bytes that can reflect
@@ -113,15 +110,11 @@ Portions of this documentation were extracted from
         The second accepted data input is a slice view of a [curve25519_dalek::scalar::Scalar] memory area,
         which captures the slices of contiguous Dalek Scalar elements.
 
-* `generators` - A sliced view of a Ristretto memory area where the
-              256-bit Ristretto Point generators used in the commitment computation are
-              stored. Bear in mind that the size of this slice must always be greater
-              or equal to the longest sequence, in terms of rows, in the table.
+* `offset_generators` - Specifies the offset used to fetch the generators
 
 # Asserts
 
-If the longest sequence in the input data is bigger than the generators` length, or If
-the data.len() value is different from the commitments.len() value.
+If the data.len() value is different from the commitments.len() value.
 
 # Panics
 

--- a/docs/commitments/get_curve25519_generators.md
+++ b/docs/commitments/get_curve25519_generators.md
@@ -1,4 +1,4 @@
-Gets the generators used in the `compute_commitments` function
+Gets the generators used in the `compute_curve25519_commitments` function
 
 In total, the function gets `generators.len()` points. These points
 are converted from 1280-bit Curve25519 points used in the scalar multiplication
@@ -25,5 +25,5 @@ for i in 0..generators.len() {
 
 # Panics
 
-If the compute `get_generators` execution in the GPU / CPU fails.
+If the compute `get_curve25519_generators` execution in the GPU / CPU fails.
 

--- a/docs/commitments/get_one_curve25519_commit.md
+++ b/docs/commitments/get_one_curve25519_commit.md
@@ -8,7 +8,7 @@ if n == 0 {
 }
 ```
 
-where `g[i]` is the i-th generator provided by `get_generators` function at the offset 0.
+where `g[i]` is the i-th generator provided by `get_curve25519_generators` function at the offset 0.
 
 # Arguments:
 
@@ -20,5 +20,5 @@ The n-th ristretto point defined as above.
 
 # Panics
 
-If the compute `get_one_commit` execution in the GPU / CPU fails.
+If the compute `get_one_curve25519_commit` execution in the GPU / CPU fails.
 

--- a/docs/commitments/update_curve25519_commitments.md
+++ b/docs/commitments/update_curve25519_commitments.md
@@ -16,7 +16,7 @@ for i in 0..data.len() {
 }
 ```
 
-The `partial_commitments` is computed by [compute_commitments].
+The `partial_commitments` is computed by [compute_curve25519_commitments].
 
 # Arguments
 
@@ -47,6 +47,6 @@ If the data.len() value is different from the commitments.len() value.
 
 # Panics
 
-If the compute `compute_commitments` execution fails.
-If the compute `compute_commitments_with_generators` execution fails.
-If the compute `get_generators` execution in the GPU / CPU fails.
+If the compute `compute_curve25519_commitments` execution fails.
+If the compute `compute_curve25519_commitments_with_generators` execution fails.
+If the compute `get_curve25519_generators` execution in the GPU / CPU fails.

--- a/examples/add_mult_commitments.rs
+++ b/examples/add_mult_commitments.rs
@@ -39,7 +39,7 @@ fn main() {
     // Do the actual commitment computation (either in cpu / gpu)
     /////////////////////////////////////////////
     let mut commitments = vec![Default::default(); 3];
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut commitments,
         &[
             weekly_pay_data.into(),

--- a/examples/get_generators.rs
+++ b/examples/get_generators.rs
@@ -36,13 +36,13 @@ fn main() {
     let offset_generators: usize = 4;
     let generators_len = 3;
     let mut gs = vec![Default::default(); generators_len];
-    get_generators(&mut gs, offset_generators as u64);
+    get_curve25519_generators(&mut gs, offset_generators as u64);
 
     /////////////////////////////////////////////
     // Do the actual commitment computation
     /////////////////////////////////////////////
     let mut commitments = vec![Default::default(); 1];
-    compute_commitments(&mut commitments, &[data.into()], 0);
+    compute_curve25519_commitments(&mut commitments, &[data.into()], 0);
 
     /////////////////////////////////////////////
     // Then we use the above generators `gs`,

--- a/examples/get_one_commit.rs
+++ b/examples/get_one_commit.rs
@@ -20,28 +20,28 @@ use curve25519_dalek::traits::Identity;
 
 fn main() {
     let mut generators = vec![Default::default(); 3];
-    get_generators(&mut generators, 0);
+    get_curve25519_generators(&mut generators, 0);
 
     /////////////////////////////////////////////
     // The first one_commit must always be the identity
     /////////////////////////////////////////////
-    assert_eq!(get_one_commit(0), RistrettoPoint::identity());
+    assert_eq!(get_one_curve25519_commit(0), RistrettoPoint::identity());
 
     /////////////////////////////////////////////
     // The second one_commit must always be the first generator
     /////////////////////////////////////////////
-    assert_eq!(get_one_commit(1), generators[0]);
+    assert_eq!(get_one_curve25519_commit(1), generators[0]);
 
     /////////////////////////////////////////////
     // The third one_commit must always be the sum of the first and second generator
     /////////////////////////////////////////////
-    assert_eq!(get_one_commit(2), generators[0] + generators[1]);
+    assert_eq!(get_one_curve25519_commit(2), generators[0] + generators[1]);
 
     /////////////////////////////////////////////
     // The fourth one_commit must always be the sum of the first through third generators
     /////////////////////////////////////////////
     assert_eq!(
-        get_one_commit(3),
+        get_one_curve25519_commit(3),
         generators[0] + generators[1] + generators[2]
     );
 }

--- a/examples/initialize_backend.rs
+++ b/examples/initialize_backend.rs
@@ -28,5 +28,5 @@ fn main() {
     /////////////////////////////////////////////
     let data: &[u64] = &[40, 32, 21, 10, 20, 35, 444];
     let mut commitments = vec![Default::default(); 1];
-    compute_commitments(&mut commitments, &[data.into()], 0_u64);
+    compute_curve25519_commitments(&mut commitments, &[data.into()], 0_u64);
 }

--- a/examples/initialize_backend_with_config.rs
+++ b/examples/initialize_backend_with_config.rs
@@ -32,6 +32,6 @@ fn main() {
     /////////////////////////////////////////////
     let data: &[u64] = &[40, 32, 21, 10, 20, 35, 444];
     let mut commitments = vec![CompressedRistretto::default(); 1];
-    compute_commitments(&mut commitments, &[data.into()], 0_u64);
+    compute_curve25519_commitments(&mut commitments, &[data.into()], 0_u64);
     assert_ne!(commitments[0], CompressedRistretto::default())
 }

--- a/examples/pass_generators_and_scalars_to_commitment.rs
+++ b/examples/pass_generators_and_scalars_to_commitment.rs
@@ -51,7 +51,7 @@ fn main() {
     // Do the actual commitment computation
     /////////////////////////////////////////////
     let mut commitments = vec![CompressedRistretto::default(); 1];
-    compute_commitments_with_generators(&mut commitments, &[data.into()], &gs);
+    compute_curve25519_commitments_with_generators(&mut commitments, &[data.into()], &gs);
 
     /////////////////////////////////////////////
     // Then we use the above generators `gs`,

--- a/examples/pass_generators_to_commitment.rs
+++ b/examples/pass_generators_to_commitment.rs
@@ -47,7 +47,7 @@ fn main() {
     // Do the actual commitment computation
     /////////////////////////////////////////////
     let mut commitments = vec![CompressedRistretto::default(); 1];
-    compute_commitments_with_generators(&mut commitments, &[data.into()], &gs);
+    compute_curve25519_commitments_with_generators(&mut commitments, &[data.into()], &gs);
 
     /////////////////////////////////////////////
     // Then we use the above generators `gs`,

--- a/examples/simple_commitment.rs
+++ b/examples/simple_commitment.rs
@@ -52,7 +52,7 @@ fn main() {
     /////////////////////////////////////////////
     // Do the actual commitment computation
     /////////////////////////////////////////////
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut commitments,
         &[data0.into(), data1.into(), data2.into(), data3.into()],
         0,

--- a/examples/simple_scalars_commitment.rs
+++ b/examples/simple_scalars_commitment.rs
@@ -48,7 +48,7 @@ fn main() {
     /////////////////////////////////////////////
     // Do the actual commitment computation
     /////////////////////////////////////////////
-    compute_commitments(&mut commitments, &[(&data).into()], 0_u64);
+    compute_curve25519_commitments(&mut commitments, &[(&data).into()], 0_u64);
 
     for (i, commit) in commitments.iter().enumerate() {
         println!("commitment {}: {:?}\n", i, commit);

--- a/examples/simple_update_commitment.rs
+++ b/examples/simple_update_commitment.rs
@@ -40,13 +40,13 @@ fn main() {
     // We compute the commitments using the exact
     // data, which stores `dense_data + scalar_data`
     /////////////////////////////////////////////
-    compute_commitments(&mut expected_commitment, &[(&expected_data).into()], 0_u64);
+    compute_curve25519_commitments(&mut expected_commitment, &[(&expected_data).into()], 0_u64);
 
     /////////////////////////////////////////////
     // Up to this point, commitment was 0. Then
     // we update it, so that `commitment = dense_data`
     /////////////////////////////////////////////
-    update_commitments(&mut commitment, &[(&dense_data).into()], 0_u64);
+    update_curve25519_commitments(&mut commitment, &[(&dense_data).into()], 0_u64);
 
     /////////////////////////////////////////////
     // We then we update the commiment, so that
@@ -58,7 +58,7 @@ fn main() {
     // commitment += (generator[0 + 2] * scalar_data[0] +
     //                  + generator[1 + 2] * scalar_data[1])
     /////////////////////////////////////////////
-    update_commitments(&mut commitment, &[(&scalar_data).into()], 2_u64);
+    update_curve25519_commitments(&mut commitment, &[(&scalar_data).into()], 2_u64);
 
     /////////////////////////////////////////////
     // We then compare the commitment results

--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -17,7 +17,7 @@ use crate::sequence::Sequence;
 use ark_bls12_381::G1Affine;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 
-#[doc = include_str!("../../docs/commitments/compute_commitments.md")]
+#[doc = include_str!("../../docs/commitments/compute_curve25519_commitments.md")]
 ///
 /// # Example 1 - Simple Commitment Computation
 ///```no_run
@@ -35,11 +35,11 @@ use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 ///```
 ///```
 #[tracing::instrument(
-    name = "compute.commitments.compute_commitments",
+    name = "compute.commitments.compute_curve25519_commitments",
     level = "info",
     skip_all
 )]
-pub fn compute_commitments(
+pub fn compute_curve25519_commitments(
     commitments: &mut [CompressedRistretto],
     data: &[Sequence],
     offset_generators: u64,
@@ -62,7 +62,7 @@ pub fn compute_commitments(
     }
 }
 
-#[doc = include_str!("../../docs/commitments/compute_commitments_with_generators.md")]
+#[doc = include_str!("../../docs/commitments/compute_curve25519_commitments_with_generators.md")]
 ///
 ///# Example 1 - Pass generators to Commitment Computation
 ///```no_run
@@ -74,11 +74,11 @@ pub fn compute_commitments(
 #[doc = include_str!("../../examples/pass_generators_and_scalars_to_commitment.rs")]
 ///```
 #[tracing::instrument(
-    name = "compute.commitments.compute_commitments_with_generators",
+    name = "compute.commitments.compute_curve25519_commitments_with_generators",
     level = "info",
     skip_all
 )]
-pub fn compute_commitments_with_generators(
+pub fn compute_curve25519_commitments_with_generators(
     commitments: &mut [CompressedRistretto],
     data: &[Sequence],
     generators: &[RistrettoPoint],
@@ -115,7 +115,7 @@ pub fn compute_commitments_with_generators(
 /// The doc tag does not seem to be working as expected. When the doc tag issue
 /// is sorted out, documentation for the bls12-381 G1 commitment computation
 /// will be created and linked below.
-#[doc = include_str!("../../docs/commitments/compute_commitments_with_generators.md")]
+#[doc = include_str!("../../docs/commitments/compute_curve25519_commitments_with_generators.md")]
 ///
 ///# Example 1 - Pass generators to Commitment Computation
 ///```no_run
@@ -126,6 +126,11 @@ pub fn compute_commitments_with_generators(
 ///```no_run
 #[doc = include_str!("../../examples/pass_generators_and_scalars_to_commitment.rs")]
 ///```
+#[tracing::instrument(
+    name = "compute.commitments.compute_bls12_381_g1_commitments_with_generators",
+    level = "info",
+    skip_all
+)]
 pub fn compute_bls12_381_g1_commitments_with_generators(
     commitments: &mut [[u8; 48]],
     data: &[Sequence],
@@ -159,7 +164,7 @@ pub fn compute_bls12_381_g1_commitments_with_generators(
     }
 }
 
-#[doc = include_str!("../../docs/commitments/update_commitments.md")]
+#[doc = include_str!("../../docs/commitments/update_curve25519_commitments.md")]
 ///
 /// # Example - Update commitments with dense and dalek scalars
 //
@@ -167,11 +172,11 @@ pub fn compute_bls12_381_g1_commitments_with_generators(
 #[doc = include_str!("../../examples/simple_update_commitment.rs")]
 /// ```
 #[tracing::instrument(
-    name = "compute.commitments.update_commitments",
+    name = "compute.commitments.update_curve25519_commitments",
     level = "info",
     skip_all
 )]
-pub fn update_commitments(
+pub fn update_curve25519_commitments(
     commitments: &mut [CompressedRistretto],
     data: &[Sequence],
     offset_generators: u64,
@@ -181,16 +186,16 @@ pub fn update_commitments(
 
     let mut partial_commitments = vec![CompressedRistretto::default(); num_columns];
 
-    compute_commitments(&mut partial_commitments, data, offset_generators);
+    compute_curve25519_commitments(&mut partial_commitments, data, offset_generators);
 
     commitments
         .iter_mut()
         .zip(partial_commitments)
         .for_each(|(c_a, c_b)| {
             *c_a = (c_a.decompress().unwrap_or_else(|| {
-                panic!("invalid ristretto point decompression on update_commitments")
+                panic!("invalid ristretto point decompression on update_curve25519_commitments")
             }) + c_b.decompress().unwrap_or_else(|| {
-                panic!("invalid ristretto point decompression on update_commitments")
+                panic!("invalid ristretto point decompression on update_curve25519_commitments")
             }))
             .compress()
         });

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -28,9 +28,9 @@ fn we_can_compute_commitments_with_a_zero_offset() {
     let data: Vec<u32> = vec![2000, 7500, 5000, 1500];
     let mut commitments = vec![CompressedRistretto::default(); 1];
     let mut generators = vec![RistrettoPoint::default(); data.len()];
-    get_generators(&mut generators, offset_generators);
+    get_curve25519_generators(&mut generators, offset_generators);
 
-    compute_commitments(&mut commitments, &[(&data).into()], offset_generators);
+    compute_curve25519_commitments(&mut commitments, &[(&data).into()], offset_generators);
 
     let expected_commit = data
         .iter()
@@ -51,9 +51,9 @@ fn we_can_compute_commitments_with_a_non_zero_offset() {
     let data: Vec<u32> = vec![2000, 7500, 5000, 1500];
     let mut commitments = vec![CompressedRistretto::default(); 1];
     let mut generators = vec![RistrettoPoint::default(); data.len()];
-    get_generators(&mut generators, offset_generators);
+    get_curve25519_generators(&mut generators, offset_generators);
 
-    compute_commitments(&mut commitments, &[(&data).into()], offset_generators);
+    compute_curve25519_commitments(&mut commitments, &[(&data).into()], offset_generators);
 
     let expected_commit = data
         .iter()
@@ -79,11 +79,11 @@ fn we_can_update_commitments() {
     let mut commitments = vec![CompressedRistretto::default(); 1];
     let mut expected_commitments = vec![CompressedRistretto::default(); 1];
 
-    update_commitments(&mut commitments, &[(&dense_data).into()], 0_u64);
+    update_curve25519_commitments(&mut commitments, &[(&dense_data).into()], 0_u64);
 
-    update_commitments(&mut commitments, &sliced_scalar_data, 2_u64);
+    update_curve25519_commitments(&mut commitments, &sliced_scalar_data, 2_u64);
 
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut expected_commitments,
         &[(&expected_data).into()],
         offset_generators,
@@ -120,11 +120,11 @@ fn we_can_update_multiple_commitments() {
 
     let expected_data_as_sequences: Vec<_> = expected_data.iter().map(|v| v.into()).collect();
 
-    update_commitments(&mut commitments, &dense_data_as_sequences, 0_u64);
+    update_curve25519_commitments(&mut commitments, &dense_data_as_sequences, 0_u64);
 
-    update_commitments(&mut commitments, &sliced_scalar_data, 5_u64);
+    update_curve25519_commitments(&mut commitments, &sliced_scalar_data, 5_u64);
 
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut expected_commitments,
         &expected_data_as_sequences,
         offset_generators,
@@ -144,7 +144,7 @@ fn compute_commitments_with_scalars_works() {
     let offset_generators = 0_u64;
     let mut data: Vec<Scalar> = vec![Scalar::ZERO; 4];
     let mut generators = vec![RistrettoPoint::default(); data.len()];
-    get_generators(&mut generators, offset_generators);
+    get_curve25519_generators(&mut generators, offset_generators);
 
     for _i in 0..2000 {
         data[0] += Scalar::ONE;
@@ -161,7 +161,7 @@ fn compute_commitments_with_scalars_works() {
 
     let mut commitments = vec![CompressedRistretto::default(); 1];
 
-    compute_commitments(&mut commitments, &[(&data).into()], offset_generators);
+    compute_curve25519_commitments(&mut commitments, &[(&data).into()], offset_generators);
 
     let expected_commit = data
         .iter()
@@ -185,7 +185,7 @@ fn commit_a_plus_commit_b_equal_to_commit_c() {
 
     let mut commitments = vec![CompressedRistretto::default(); 3];
 
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut commitments,
         &[(&data_a).into(), (&data_b).into(), (&data_c).into()],
         offset_generators,
@@ -229,7 +229,7 @@ fn commit_1_plus_commit_1_plus_commit_1_equal_to_commit_3() {
 
     let mut commitments = vec![CompressedRistretto::default(); 4];
 
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut commitments,
         &[
             (&data_a).into(),
@@ -284,7 +284,7 @@ fn commit_a_times_52_plus_commit_b_equal_to_commit_c() {
 
     let mut commitments = vec![CompressedRistretto::default(); 3];
 
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut commitments,
         &[(&data_a).into(), (&data_b).into(), (&data_c).into()],
         offset_generators,
@@ -335,7 +335,7 @@ fn commit_negative_a_plus_commit_negative_b_equal_to_commit_c() {
 
     let mut commitments = vec![CompressedRistretto::default(); 3];
 
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut commitments,
         &[(&data_a).into(), (&data_b).into(), (&data_c).into()],
         offset_generators,
@@ -385,7 +385,7 @@ fn different_word_size_and_rows_in_commit_a_plus_commit_b_plus_commit_c_equal_to
 
     let mut commitments = vec![CompressedRistretto::default(); 4];
 
-    compute_commitments(
+    compute_curve25519_commitments(
         &mut commitments,
         &[
             (&data_a).into(),
@@ -441,7 +441,7 @@ fn sending_generators_to_gpu_produces_correct_commitment_results() {
         .collect();
     let mut commitments = vec![CompressedRistretto::default(); 1];
 
-    compute_commitments_with_generators(&mut commitments, &[(&data).into()], &generator_points);
+    compute_curve25519_commitments_with_generators(&mut commitments, &[(&data).into()], &generator_points);
 
     let mut expected_commit = RistrettoPoint::from_uniform_bytes(&[0_u8; 64]);
 
@@ -520,7 +520,7 @@ fn sending_generators_and_scalars_to_gpu_produces_correct_commitment_results() {
         .collect();
     let mut commitments = vec![CompressedRistretto::default(); 1];
 
-    compute_commitments_with_generators(&mut commitments, &[(&data).into()], &generators);
+    compute_curve25519_commitments_with_generators(&mut commitments, &[(&data).into()], &generators);
 
     let expected_commit = data
         .iter()
@@ -538,7 +538,7 @@ fn we_can_compute_commitments_to_signed_values_with_a_zero_offset() {
     let data1: Vec<i64> = vec![-2];
     let data2: Vec<i64> = vec![2];
     let mut commitments = vec![CompressedRistretto::default(); 2];
-    compute_commitments(&mut commitments, &[(&data1).into(), (&data2).into()], 0);
+    compute_curve25519_commitments(&mut commitments, &[(&data1).into(), (&data2).into()], 0);
 
     assert_eq!(
         commitments[0].decompress().unwrap(),
@@ -552,7 +552,7 @@ fn commit_to_signed_slice_and_its_negatives_gives_the_zero_commit() {
     let b: &[i32] = &[2, -4, 6, -7, -8];
     let z: &[i32] = &[0, 0, 0, 0, 0];
     let mut commitments = vec![CompressedRistretto::default(); 3];
-    compute_commitments(&mut commitments, &[a.into(), b.into(), z.into()], 0);
+    compute_curve25519_commitments(&mut commitments, &[a.into(), b.into(), z.into()], 0);
     assert!(
         commitments[0].decompress().unwrap() + commitments[1].decompress().unwrap()
             == commitments[2].decompress().unwrap()

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -441,7 +441,11 @@ fn sending_generators_to_gpu_produces_correct_commitment_results() {
         .collect();
     let mut commitments = vec![CompressedRistretto::default(); 1];
 
-    compute_curve25519_commitments_with_generators(&mut commitments, &[(&data).into()], &generator_points);
+    compute_curve25519_commitments_with_generators(
+        &mut commitments,
+        &[(&data).into()],
+        &generator_points,
+    );
 
     let mut expected_commit = RistrettoPoint::from_uniform_bytes(&[0_u8; 64]);
 
@@ -520,7 +524,11 @@ fn sending_generators_and_scalars_to_gpu_produces_correct_commitment_results() {
         .collect();
     let mut commitments = vec![CompressedRistretto::default(); 1];
 
-    compute_curve25519_commitments_with_generators(&mut commitments, &[(&data).into()], &generators);
+    compute_curve25519_commitments_with_generators(
+        &mut commitments,
+        &[(&data).into()],
+        &generators,
+    );
 
     let expected_commit = data
         .iter()

--- a/src/compute/generators.rs
+++ b/src/compute/generators.rs
@@ -22,7 +22,11 @@ use std::mem::MaybeUninit;
 /// ```no_run
 #[doc = include_str!("../../examples/get_generators.rs")]
 /// ```
-#[tracing::instrument(name = "compute.generators.get_curve25519_generators", level = "info", skip_all)]
+#[tracing::instrument(
+    name = "compute.generators.get_curve25519_generators",
+    level = "info",
+    skip_all
+)]
 pub fn get_curve25519_generators(generators: &mut [RistrettoPoint], offset_generators: u64) {
     init_backend();
 
@@ -49,7 +53,11 @@ pub fn get_curve25519_generators(generators: &mut [RistrettoPoint], offset_gener
 /// ```no_run
 #[doc = include_str!("../../examples/get_one_commit.rs")]
 /// ```
-#[tracing::instrument(name = "compute.generators.get_one_curve25519_commit", level = "info", skip_all)]
+#[tracing::instrument(
+    name = "compute.generators.get_one_curve25519_commit",
+    level = "info",
+    skip_all
+)]
 pub fn get_one_curve25519_commit(n: u64) -> RistrettoPoint {
     init_backend();
 

--- a/src/compute/generators.rs
+++ b/src/compute/generators.rs
@@ -15,15 +15,15 @@ use super::backend::init_backend;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use std::mem::MaybeUninit;
 
-#[doc = include_str!("../../docs/commitments/get_generators.md")]
+#[doc = include_str!("../../docs/commitments/get_curve25519_generators.md")]
 ///
-/// # Example - Getting the Generators used in the `compute_commitments` function
+/// # Example - Getting the Generators used in the `compute_curve25519_commitments` function
 //
 /// ```no_run
 #[doc = include_str!("../../examples/get_generators.rs")]
 /// ```
-#[tracing::instrument(name = "compute.generators.get_generators", level = "info", skip_all)]
-pub fn get_generators(generators: &mut [RistrettoPoint], offset_generators: u64) {
+#[tracing::instrument(name = "compute.generators.get_curve25519_generators", level = "info", skip_all)]
+pub fn get_curve25519_generators(generators: &mut [RistrettoPoint], offset_generators: u64) {
     init_backend();
 
     unsafe {
@@ -37,20 +37,20 @@ pub fn get_generators(generators: &mut [RistrettoPoint], offset_generators: u64)
         );
 
         if ret_get_generators != 0 {
-            panic!("Error during get_generators call");
+            panic!("Error during get_curve25519_generators call");
         }
     }
 }
 
-#[doc = include_str!("../../docs/commitments/get_one_commit.md")]
+#[doc = include_str!("../../docs/commitments/get_one_curve25519_commit.md")]
 ///
 /// # Example - Getting the i-th One Commit
 //
 /// ```no_run
 #[doc = include_str!("../../examples/get_one_commit.rs")]
 /// ```
-#[tracing::instrument(name = "compute.generators.get_one_commit", level = "info", skip_all)]
-pub fn get_one_commit(n: u64) -> RistrettoPoint {
+#[tracing::instrument(name = "compute.generators.get_one_curve25519_commit", level = "info", skip_all)]
+pub fn get_one_curve25519_commit(n: u64) -> RistrettoPoint {
     init_backend();
 
     unsafe {
@@ -60,7 +60,7 @@ pub fn get_one_commit(n: u64) -> RistrettoPoint {
         let ret_get_one_commit = blitzar_sys::sxt_curve25519_get_one_commit(one_commit_ptr, n);
 
         if ret_get_one_commit != 0 {
-            panic!("Error during get_one_commit call");
+            panic!("Error during get_one_curve25519_commit call");
         }
 
         one_commit.assume_init()

--- a/src/compute/generators_tests.rs
+++ b/src/compute/generators_tests.rs
@@ -26,9 +26,9 @@ fn get_generators_is_the_same_used_in_commitment_computation() {
     let mut generators = vec![RistrettoPoint::from_uniform_bytes(&[0_u8; 64]); data.len()];
 
     // convert the generator points to compressed ristretto
-    get_generators(&mut generators, 0_u64);
+    get_curve25519_generators(&mut generators, 0_u64);
 
-    compute_commitments(&mut commitments, &[(&data).into()], offset_generators);
+    compute_curve25519_commitments(&mut commitments, &[(&data).into()], offset_generators);
 
     let mut expected_commit = RistrettoPoint::from_uniform_bytes(&[0_u8; 64]);
 
@@ -57,9 +57,9 @@ fn get_generators_with_offset_is_the_same_used_in_commitment_computation() {
     let mut generators = vec![RistrettoPoint::from_uniform_bytes(&[0_u8; 64]); generators_len];
     let mut commitments = vec![CompressedRistretto::default(); 1];
 
-    get_generators(&mut generators, offset_generators as u64);
+    get_curve25519_generators(&mut generators, offset_generators as u64);
 
-    compute_commitments(&mut commitments, &[(&data).into()], 0_u64);
+    compute_curve25519_commitments(&mut commitments, &[(&data).into()], 0_u64);
 
     let expected_commit = data[offset_generators..]
         .iter()
@@ -77,9 +77,9 @@ fn get_one_commit_is_valid() {
     let generators_len = 3;
     let mut generators = vec![RistrettoPoint::from_uniform_bytes(&[0_u8; 64]); generators_len];
 
-    get_generators(&mut generators, 0);
+    get_curve25519_generators(&mut generators, 0);
 
-    assert_eq!(get_one_commit(0), RistrettoPoint::identity());
-    assert_eq!(get_one_commit(1), generators[0]);
-    assert_eq!(get_one_commit(2), generators[0] + generators[1]);
+    assert_eq!(get_one_curve25519_commit(0), RistrettoPoint::identity());
+    assert_eq!(get_one_curve25519_commit(1), generators[0]);
+    assert_eq!(get_one_curve25519_commit(2), generators[0] + generators[1]);
 }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -19,15 +19,15 @@ pub use backend::{init_backend, init_backend_with_config, BackendConfig};
 
 mod commitments;
 pub use commitments::{
-    compute_bls12_381_g1_commitments_with_generators, compute_commitments,
-    compute_commitments_with_generators, update_commitments,
+    compute_bls12_381_g1_commitments_with_generators, compute_curve25519_commitments,
+    compute_curve25519_commitments_with_generators, update_curve25519_commitments,
 };
 
 #[cfg(test)]
 mod commitments_tests;
 
 mod generators;
-pub use generators::{get_generators, get_one_commit};
+pub use generators::{get_curve25519_generators, get_one_curve25519_commit};
 
 #[cfg(test)]
 mod generators_tests;

--- a/src/proof/inner_product.rs
+++ b/src/proof/inner_product.rs
@@ -34,7 +34,7 @@ impl InnerProductProof {
     /// ```text
     /// let np = 1ull << ceil(log2(n));
     /// let G = vec![RISTRETTO_BASEPOINT_POINT; np + 1];
-    /// crate::compute::get_generators(G, generators_offset)`.
+    /// crate::compute::get_curve25519_generators(G, generators_offset)`.
     /// ```
     ///
     /// The `verifier` transcript is passed in as a parameter so that the
@@ -163,7 +163,7 @@ impl InnerProductProof {
     /// ```text
     /// let np = 1ull << ceil(log2(n));
     /// let G = vec![RISTRETTO_BASEPOINT_POINT; np + 1];
-    /// crate::compute::get_generators(G, generators_offset)`.
+    /// crate::compute::get_curve25519_generators(G, generators_offset)`.
     /// ```
     ///
     /// Note that we don't have any restriction to the `n` value, other than

--- a/src/proof/inner_product_tests.rs
+++ b/src/proof/inner_product_tests.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 use super::*;
 
-use crate::compute::get_generators;
+use crate::compute::get_curve25519_generators;
 use core::{mem, slice};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
@@ -35,7 +35,7 @@ fn test_prove_and_verify_with_given_n_and_generators_offset(n: u64, generators_o
     let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
     let g = {
         let mut temp_g = vec![RistrettoPoint::default(); n as usize];
-        get_generators(&mut temp_g, generators_offset);
+        get_curve25519_generators(&mut temp_g, generators_offset);
         temp_g
     };
 


### PR DESCRIPTION
# Rationale for this change
Blitzar currently supports computing commitments with `curve25519` and `bls12-381` elements. This work updates the function names to support multiple curves. The refactored function names follow the naming conventions from https://github.com/spaceandtimelabs/blitzar/pull/28 and https://github.com/spaceandtimelabs/blitzar-rs/pull/8. 

# What changes are included in this PR?
- `compute_commitments` is now `compute_curve25519_commitments`
- `compute_commitments_with_generators` is now `compute_curve25519_commitments_with_generators`
- `get_generators` is now `get_curve25519_generators`
- `get_one_commit` is now `get_one_curve25519_commit`
- Supporting files are updated with the new function names.
- A missing tracing statement is added to the `compute_bls12_381_g1_commitments_with_generators` function.

# Are these changes tested?
Yes, the changes were tested locally with `cargo test` and `cargo bench`. Both ran successfully.