### PR TITLE
refactor: remove tracing::instrument from codebase (PROOF-785)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
-tracing = { version = "0.1.36" }
 
 # this sections is shared by tests, benchmarks, and examples
 [dev-dependencies]

--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -33,11 +33,6 @@ use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 ///```no_run
 #[doc = include_str!("../../examples/simple_scalars_commitment.rs")]
 ///```
-#[tracing::instrument(
-    name = "compute.commitments.compute_curve25519_commitments",
-    level = "info",
-    skip_all
-)]
 pub fn compute_curve25519_commitments(
     commitments: &mut [CompressedRistretto],
     data: &[Sequence],
@@ -72,11 +67,6 @@ pub fn compute_curve25519_commitments(
 ///```no_run
 #[doc = include_str!("../../examples/pass_generators_and_scalars_to_commitment.rs")]
 ///```
-#[tracing::instrument(
-    name = "compute.commitments.compute_curve25519_commitments_with_generators",
-    level = "info",
-    skip_all
-)]
 pub fn compute_curve25519_commitments_with_generators(
     commitments: &mut [CompressedRistretto],
     data: &[Sequence],
@@ -116,11 +106,6 @@ pub fn compute_curve25519_commitments_with_generators(
 ///```no_run
 #[doc = include_str!("../../examples/pass_bls12_381_g1_generators_to_commitment.rs")]
 ///```
-#[tracing::instrument(
-    name = "compute.commitments.compute_bls12_381_g1_commitments_with_generators",
-    level = "info",
-    skip_all
-)]
 pub fn compute_bls12_381_g1_commitments_with_generators(
     commitments: &mut [[u8; 48]],
     data: &[Sequence],
@@ -160,11 +145,6 @@ pub fn compute_bls12_381_g1_commitments_with_generators(
 /// ```no_run
 #[doc = include_str!("../../examples/simple_update_commitment.rs")]
 /// ```
-#[tracing::instrument(
-    name = "compute.commitments.update_curve25519_commitments",
-    level = "info",
-    skip_all
-)]
 pub fn update_curve25519_commitments(
     commitments: &mut [CompressedRistretto],
     data: &[Sequence],

--- a/src/compute/generators.rs
+++ b/src/compute/generators.rs
@@ -21,11 +21,6 @@ use std::mem::MaybeUninit;
 /// ```no_run
 #[doc = include_str!("../../examples/get_generators.rs")]
 /// ```
-#[tracing::instrument(
-    name = "compute.generators.get_curve25519_generators",
-    level = "info",
-    skip_all
-)]
 pub fn get_curve25519_generators(generators: &mut [RistrettoPoint], offset_generators: u64) {
     init_backend();
 
@@ -51,11 +46,6 @@ pub fn get_curve25519_generators(generators: &mut [RistrettoPoint], offset_gener
 /// ```no_run
 #[doc = include_str!("../../examples/get_one_commit.rs")]
 /// ```
-#[tracing::instrument(
-    name = "compute.generators.get_one_curve25519_commit",
-    level = "info",
-    skip_all
-)]
 pub fn get_one_curve25519_commit(n: u64) -> RistrettoPoint {
     init_backend();
 

--- a/src/proof/inner_product.rs
+++ b/src/proof/inner_product.rs
@@ -107,7 +107,6 @@ impl InnerProductProof {
     /// - a (in): array with non-zero length n
     /// - b (in): array with non-zero length n
     /// - generators_offset (in): offset used to fetch the bases
-    #[tracing::instrument(name = "proof.inner_product.create", level = "info", skip_all)]
     pub fn create(
         transcript: &mut Transcript,
         a: &[Scalar],
@@ -179,7 +178,6 @@ impl InnerProductProof {
     ///                 `InnerProductProof::create(...)`
     /// - b (in): array with non-zero length n, the same one used by `InnerProductProof::create(...)`
     /// - generators_offset (in): offset used to fetch the bases
-    #[tracing::instrument(name = "proof.inner_product.verify", level = "info", skip_all)]
     pub fn verify(
         &self,
         transcript: &mut Transcript,


### PR DESCRIPTION
# Rationale for this change
Remove `tracing::instrument` from `blitzar-rs`. Tracing can be added to the `proofs` project whenever `blitzar` is called.

# What changes are included in this PR?
- The `tracing` crate is removed from the `Cargo.toml`.
- `tracing::instrument` is removed throughout. 

# Are these changes tested?
Yes, using `cargo test`, `cargo test --release`, `cargo build`, `cargo build --release`, and `cargo bench`.