### PR TITLE
docs: clean up docs formatting (PROOF-711)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To get a local copy up and running, consider the following steps.
 
 * [Rust 1.69.0](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* Nvidia Toolkit Driver Version: >= 525.60.13 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* Nvidia Toolkit Driver Version: >= 535.104.05 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Blitzar-rs is a High-Level rust wrapper for the [blitzar-sys crate](https://gith
 
 The crate provides
 
-* Functions for doing group operations on [Curve-25519](https://en.wikipedia.org/wiki/Curve25519) and [Ristretto25519](https://ristretto.group/) elements.
+* Functions for doing group operations on [Curve-25519](https://en.wikipedia.org/wiki/Curve25519), [Ristretto25519](https://ristretto.group/) and [bls12-381 G1](https://electriccoin.co/blog/new-snark-curve/) elements.
 * An implementation of [Inner Product Argument Protocol](https://eprint.iacr.org/2017/1066.pdf) for producing and verifying a compact proof of the inner product of two vectors.
 
 **WARNING**: This project has not undergone a security audit and is NOT ready
@@ -98,7 +98,7 @@ Note: we interchangeably use the terms "multi-scalar multiplication" and "multie
 
 The Blitzar implementation allows for computation of multiple, potentially different length, MSMs simultaneously. Additionally, either built-in, precomputed, generators can be used, or they can be provided as needed.
 
-Currently, Blitzar supports Curve25519 as the group. We're always working to expand the curves that we support, so check back for updates.
+Currently, Blitzar supports Curve25519 and bls12-381 G1 as groups. We're always working to expand the curves that we support, so check back for updates.
 
 #### Inner Product Argument
 
@@ -119,7 +119,7 @@ To get a local copy up and running, consider the following steps.
 
 * [Rust 1.69.0](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* Nvidia Toolkit Driver Version: >= 530.30.02 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* Nvidia Toolkit Driver Version: >= 525.60.13 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 
@@ -141,7 +141,7 @@ To add this library to your project, update your `Cargo.toml` file with the foll
 
 ```
 [dependencies]
-blitzar = "0.2.0"
+blitzar = <version_number>
 ```
 
 ### Feature Flags

--- a/docs/commitments/compute_bls12_381_g1_commitments_with_generators.md
+++ b/docs/commitments/compute_bls12_381_g1_commitments_with_generators.md
@@ -1,4 +1,4 @@
-Computes the Pedersen commitment for a given input data using bls12-381 G1 curve elements.
+Computes the Pedersen commitment for a given input data using `bls12-381` `G1` curve elements.
 
 In total, the function computes `data.len()` commitments,
 which is related to the total number of columns in the data table. The commitment
@@ -26,9 +26,9 @@ let M_j = [
 
 This message `M_j` cannot be decrypted from `C_j`. The curve point `C_j`
 is generated in a unique way using `M_j` and a
-set of 1152-bit bls12-381 G1 curve elements in projective form `G_i`, called row generators.
+set of 1152-bit `bls12-381` `G1` curve elements in projective form `G_i`, called row generators.
 Although our GPU code uses 1152-bit generators during the scalar 
-multiplication, these generators are passed as 764-bit G1 affine elements
+multiplication, these generators are passed as 764-bit `G1` affine elements
 and only converted to 1152-bit projective elements inside the GPU/CPU.
 
 The total number of generators used to compute `C_j` is equal to 
@@ -51,7 +51,7 @@ let C_j = compress(C_j_temp); // this is a 384-bit bls12-381 G1 point
 Ps: the above is only illustrative code. It will not compile.
 
 Here `curr_data_ji` are simply 256-bit scalars, `C_j_temp` and `G_i` are
-1152-bit bls12-381 G1 curve elements in projective form and `C_j` is a 384-bit compressed bls12-381 G1 point.
+1152-bit `bls12-381` `G1` curve elements in projective form and `C_j` is a 384-bit compressed `bls12-381` `G1` point.
 
 Given `M_j` and `G_i`, it is easy to verify that the Pedersen
 commitment `C_j` is the correctly generated output. However,
@@ -68,7 +68,7 @@ Portions of this documentation were extracted from
 
 # Arguments
 
-* `commitments` - A sliced view of a compressed bls12-381 G1 curve element memory area where the 
+* `commitments` - A sliced view of a compressed `bls12-381` `G1` curve element memory area where the 
                384-bit point results will be written to. Please,
                you need to guarantee that this slice captures exactly
                `data.len()` element positions.
@@ -80,14 +80,14 @@ Portions of this documentation were extracted from
         your desired amount of `num_rows` in the sequence. After all,
         we infer the `num_rows` from `data[i].data_slice.len() / data[i].element_size`.
 
-* `generators` - A sliced view of a bls12-381 G1 curve affine element memory area where the
+* `generators` - A sliced view of a `bls12-381` `G1` curve affine element memory area where the
               768-bit point generators used in the commitment computation are
               stored. Bear in mind that the size of this slice must always be greater
               or equal to the longest sequence, in terms of rows, in the table.
 
 # Asserts
 
-If the longest sequence in the input data is bigger than the generators` length, or if
+If the longest sequence in the input data is bigger than the generators length, or if
 the `data.len()` value is different from the `commitments.len()` value.
 
 # Panics

--- a/docs/commitments/compute_curve25519_commitments.md
+++ b/docs/commitments/compute_curve25519_commitments.md
@@ -1,13 +1,13 @@
-Computes the Pedersen commitment for a given input data.
+Computes the Pedersen commitment for a given input data with internally generated `curve25519` elements.
 
 In total, the function computes `data.len()` commitments,
 which is related to the total number of columns in the data table. The commitment
 results are stored as 256-bit Ristretto points in the `commitments` variable.
 
-The j-th Pedersen commitment is a 256-bit Ristretto point C_j over the
-curve25519 elliptic curve that is cryptographically binded to a data message vector M_j. This `M_j` vector is populated according to the type of the `data` given.
+The `j`-th Pedersen commitment is a 256-bit Ristretto point `C_j` over the
+`curve25519` elliptic curve that is cryptographically binded to a data message vector `M_j`. This `M_j` vector is populated according to the type of the `data` given.
 
-For instance, for an input data table specified as a [crate::sequence::Sequence] slice view, we populate M_j as follows:
+For instance, for an input data table specified as a [crate::sequence::Sequence] slice view, we populate `M_j` as follows:
 
 ```text
 let el_size = data[j].element_size; // sizeof of each element in the current j-th column
@@ -24,7 +24,7 @@ let M_j = [
 ];
 ```
 
-Now, for an input data table specified as a [curve25519_dalek::scalar::Scalar] view, we populate M_j as follows:
+Now, for an input data table specified as a [curve25519_dalek::scalar::Scalar] view, we populate `M_j` as follows:
 
 ```text
 let el_size = 32; // sizeof of each element in the current j-th column
@@ -41,12 +41,12 @@ let M_j = [
 ];
 ```
 
-This message M_j cannot be decrypted from C_j. The curve point C_j is generated in a unique way using M_j and a
-set of random 1280-bit curve25519 points G_{i + offset_generators}, called row generators. The total number of generators used to compute C_j is equal to the number of `num_rows` in the data\[j] sequence. To access those generators, use the \[get_curve25519_generators\] function.
+This message `M_j` cannot be decrypted from `C_j`. The curve point `C_j` is generated in a unique way using `M_j` and a
+set of random 1280-bit `curve25519` points `G_{i + offset_generators}`, called row generators. The total number of generators used to compute `C_j` is equal to the number of `num_rows` in the `data[j]` sequence. To access those generators, use the `get_curve25519_generators` function.
 
 
 The following formula
-is specified to obtain the C_j commitment when the input table is a 
+is specified to obtain the `C_j` commitment when the input table is a 
 [crate::sequence::Sequence] view:
 
 ```text
@@ -77,36 +77,36 @@ let C_j = convert_to_ristretto(C_j_temp); // this is a 256-bit Ristretto point
 
 Ps: the above is only illustrative code. It will not compile.
 
-Here `curr_data_ji` are simply 256-bit scalars, C_j_temp and G_{i + offset_generators} are
-1280-bit curve25519 points and C_j is a 256-bit Ristretto point.
+Here `curr_data_ji` are simply 256-bit scalars, `C_j_temp` and `G_{i + offset_generators}` are
+1280-bit `curve25519` points and `C_j` is a 256-bit Ristretto point.
 
-Given M_j and G_{i + offset_generators}, it is easy to verify that the Pedersen
-commitment C_j is the correctly generated output. However,
-the Pedersen commitment generated from M_j and G_{i + offset_generators} is cryptographically
-binded to the message M_j because finding alternative inputs M_j* and 
-G_{i + offset_generators}* for which the Pedersen commitment generates the same point C_j
+Given `M_j` and `G_{i + offset_generators}`, it is easy to verify that the Pedersen
+commitment `C_j` is the correctly generated output. However,
+the Pedersen commitment generated from `M_j` and `G_{i + offset_generators}` is cryptographically
+binded to the message `M_j` because finding alternative inputs `M_j*` and 
+`G_{i + offset_generators}*` for which the Pedersen commitment generates the same point `C_j`
 requires an infeasible amount of computation.
 
 To guarantee proper execution so that the backend is correctly set,
 this `compute_curve25519_commitments` always calls the `init_backend()` function.
 
 Portions of this documentation were extracted from
-[here](findora.org/faq/crypto/pedersen-commitment-with-elliptic-curves/)
+[here](findora.org/faq/crypto/pedersen-commitment-with-elliptic-curves/).
 
 # Arguments
 
-* `commitments` - A sliced view of a CompressedRistretto memory area where the 
+* `commitments` - A sliced view of a `CompressedRistretto` memory area where the 
                256-bit Ristretto point results will be written to. Please,
                you need to guarantee that this slice captures exactly
-               data.len() element positions.
+               `data.len()` element positions.
 
-* `data` - A generic slice view T. Currently, we support
+* `data` - A generic slice view `T`. Currently, we support
         two different types of slices. First, a slice view of a [crate::sequence::Sequence], 
-        which captures the slices of contiguous u8 memory elements.
-        In this case, you need to guarantee that the contiguous u8 slice view
+        which captures the slices of contiguous `u8` memory elements.
+        In this case, you need to guarantee that the contiguous `u8` slice view
         captures the correct amount of bytes that can reflect
         your desired amount of `num_rows` in the sequence. After all,
-        we infer the `num_rows` from data\[i].data_slice.len() / data\[i].element_size.
+        we infer the `num_rows` from `data[i].data_slice.len() / data[i].element_size`.
         The second accepted data input is a slice view of a [curve25519_dalek::scalar::Scalar] memory area,
         which captures the slices of contiguous Dalek Scalar elements.
 
@@ -114,7 +114,7 @@ Portions of this documentation were extracted from
 
 # Asserts
 
-If the data.len() value is different from the commitments.len() value.
+If the `data.len()` value is different from the `commitments.len()` value.
 
 # Panics
 

--- a/docs/commitments/compute_curve25519_commitments_with_generators.md
+++ b/docs/commitments/compute_curve25519_commitments_with_generators.md
@@ -1,11 +1,11 @@
-Computes the Pedersen commitment for a given input data using curve25519 elements.
+Computes the Pedersen commitment for a given input data using `curve25519` elements.
 
 In total, the function computes `data.len()` commitments,
 which is related to the total number of columns in the data table. The commitment
 results are stored as 256-bit Ristretto points in the `commitments` variable.
 
 The `j`-th Pedersen commitment is a 256-bit Ristretto point `C_j` over the
-curve25519 elliptic curve that is cryptographically binded to a data message vector `M_j`. This `M_j` vector is populated according to the type of the `data` given.
+`curve25519` elliptic curve that is cryptographically binded to a data message vector `M_j`. This `M_j` vector is populated according to the type of the `data` given.
 
 For instance, for an input data table specified as a [crate::sequence::Sequence] slice view, we populate `M_j` as follows:
 
@@ -43,7 +43,7 @@ let M_j = [
 
 This message `M_j` cannot be decrypted from `C_j`. The curve point `C_j`
 is generated in a unique way using `M_j` and a
-set of 1280-bit curve25519 points `G_i`, called row generators.
+set of 1280-bit `curve25519` points `G_i`, called row generators.
 Although our GPU code uses 1280-bit generators during the scalar 
 multiplication, these generators are passed as 256-bit Ristretto points
 and only converted to 1280-bit points inside the GPU/CPU.
@@ -81,7 +81,7 @@ let C_j = convert_to_ristretto(C_j_temp); // this is a 256-bit Ristretto point
 Ps: the above is only illustrative code. It will not compile.
 
 Here `curr_data_ji` are simply 256-bit scalars, `C_j_temp` and `G_i` are
-1280-bit curve25519 points and `C_j` is a 256-bit Ristretto point.
+1280-bit `curve25519` points and `C_j` is a 256-bit Ristretto point.
 
 Given `M_j` and `G_i`, it is easy to verify that the Pedersen
 commitment `C_j` is the correctly generated output. However,
@@ -98,7 +98,7 @@ Portions of this documentation were extracted from
 
 # Arguments
 
-* `commitments` - A sliced view of a CompressedRistretto memory area where the 
+* `commitments` - A sliced view of a `CompressedRistretto` memory area where the 
                256-bit Ristretto point results will be written to. Please,
                you need to guarantee that this slice captures exactly
                data.len() element positions.
@@ -120,7 +120,7 @@ Portions of this documentation were extracted from
 
 # Asserts
 
-If the longest sequence in the input data is bigger than the generators` length, or if
+If the longest sequence in the input data is bigger than the generators length, or if
 the `data.len()` value is different from the `commitments.len()` value.
 
 # Panics

--- a/docs/commitments/get_curve25519_generators.md
+++ b/docs/commitments/get_curve25519_generators.md
@@ -1,7 +1,7 @@
-Gets the generators used in the `compute_curve25519_commitments` function
+Gets the generators used in the `compute_curve25519_commitments` function.
 
 In total, the function gets `generators.len()` points. These points
-are converted from 1280-bit Curve25519 points used in the scalar multiplication
+are converted from 1280-bit `curve25519` points used in the scalar multiplication
 of the commitment computation, to 256-bit Ristretto points. This function
 also allows the user to provide an offset so that a shift is applied in the
 retrieval. The following operation is applied:
@@ -19,8 +19,8 @@ for i in 0..generators.len() {
               be written into.
 * `offset_generators` - A value that is used to shift the get generator operation by
                         `offset_generators` values. With this shift, we have
-                        generator\[0] holding the value of randomly_generate_curve25519_point(0 + offset),
-                        generator\[1] holding the value of randomly_generate_curve25519_point(1 + offset),
+                        `generator[0]` holding the value of `randomly_generate_curve25519_point(0 + offset)`,
+                        `generator[1]` holding the value of `randomly_generate_curve25519_point(1 + offset)`,
                         and so on.
 
 # Panics

--- a/docs/commitments/get_one_curve25519_commit.md
+++ b/docs/commitments/get_one_curve25519_commit.md
@@ -1,4 +1,6 @@
-Gets the n-th ristretto point defined as:
+Gets the `n`-th Ristretto point.
+
+The `n`-th Ristretto point is defined as:
 
 ```text
 if n == 0 {
@@ -8,15 +10,15 @@ if n == 0 {
 }
 ```
 
-where `g[i]` is the i-th generator provided by `get_curve25519_generators` function at the offset 0.
+where `g[i]` is the `i`-th generator provided by `get_curve25519_generators` function at the offset `0`.
 
-# Arguments:
+# Arguments
 
-* `n` - the n-th ristretto point to be fetched.
+* `n` - the `n`-th Ristretto point to be fetched.
 
-# Return:
+# Return
 
-The n-th ristretto point defined as above.
+The `n`-th Ristretto point defined as above.
 
 # Panics
 

--- a/docs/commitments/init_backend.md
+++ b/docs/commitments/init_backend.md
@@ -1,11 +1,11 @@
-Responsible for initializing only once the C++ commitment backend.
+Responsible for initializing the C++ commitment backend.
 
 This function initializes the backend so that computations
-can proceed either in the CPU or in the GPU. The backend
+can proceed either in the CPU or in the GPU. It is only called once. The backend
 type must be specified during `build` time using the following flags:
 
 ```text
-cargo build --features pip-cpu # only the pippenger commitment CPU is used
+cargo build --features pip-cpu # only the Pippenger commitment CPU is used
 cargo build --features naive-gpu # only the naive commitment GPU is used
 cargo build --features naive-cpu # only the naive commitment CPU is used
 ```

--- a/docs/commitments/init_backend_with_config.md
+++ b/docs/commitments/init_backend_with_config.md
@@ -1,11 +1,11 @@
-Responsible for initializing only once the C++ commitment backend.
+Responsible for initializing the C++ commitment backend and producing a specified number of generators.
 
 This function initializes the backend so that computations
-can proceed either in the CPU or in the GPU. The backend
+can proceed either in the CPU or in the GPU. It is only called once. The backend
 type must be specified during `build` time using the following flags:
 
 ```text
-cargo build --features pip-cpu # only the pippenger commitment CPU is used
+cargo build --features pip-cpu # only the Pippenger commitment CPU is used
 cargo build --features naive-gpu # only the naive commitment GPU is used
 cargo build --features naive-cpu # only the naive commitment CPU is used
 ```
@@ -21,11 +21,10 @@ During this initialization process, the user can also specify a
 some generators. Those are later used in the commitment computation,
 preventing the generators from being created over and over again.
 
-//
-Also, any `compute` function will call this `init_backend_with_precomputation`
+Any `compute` function will call this `init_backend_with_precomputation`
 securing that the backend is always in a proper state.
  
-Finally, to guarantee that the code inside this function is not
+To guarantee that the code inside this function is not
 initialized multiple times, we use the `std::sync::Once` scheme.
 
 # Arguments

--- a/docs/commitments/update_curve25519_commitments.md
+++ b/docs/commitments/update_curve25519_commitments.md
@@ -1,8 +1,6 @@
-Updates given commitments
+Updates given commitments using `curve25519` elements.
 
-This function updates the `commitments` data according to:
-
-1. If the data input is either a slice view of a [crate::sequence::Sequence] or a slice view of a [curve25519_dalek::scalar::Scalar], then:
+If the data input is either a slice view of a [crate::sequence::Sequence] or a slice view of a [curve25519_dalek::scalar::Scalar], then his function updates the `commitments` data according to::
 
 ```text
 let partial_commitments = vec![CompressedRistretto::zero(); data.len()];
@@ -20,30 +18,30 @@ The `partial_commitments` is computed by [compute_curve25519_commitments].
 
 # Arguments
 
-* `commitments` - A sliced view of a CompressedRistretto memory area where the 
+* `commitments` - A sliced view of a `CompressedRistretto` memory area where the 
                256-bit Ristretto point results will be written to. Please,
                you need to guarantee that this slice captures exactly
-               data.len() element positions.
+               `data.len()` element positions.
 
-* `data` - A generic slice view T. Currently, we support
+* `data` - A generic slice view `T`. Currently, we support
         two different types of slices. First, a slice view of a [crate::sequence::Sequence], 
         which captures the slices of contiguous u8 memory elements.
-        In this case, you need to guarantee that the contiguous u8 slice view
+        In this case, you need to guarantee that the contiguous `u8` slice view
         captures the correct amount of bytes that can reflect
         your desired amount of `num_rows` in the sequence. After all,
-        we infer the `num_rows` from data\[i].data_slice.len() / data\[i].element_size.
+        we infer the `num_rows` from `data[i].data_slice.len() / data[i].element_size`.
         The second accepted data input is a slice view of a [curve25519_dalek::scalar::Scalar] memory area,
         which captures the slices of contiguous Dalek Scalar elements.
 
 * `offset_generators` - A value that is used to shift the get generator operation by
                         `offset_generators` values. With this shift, we have
-                        generator\[0] holding the value of randomly_generate_curve25519_point(0 + offset),
-                        generator\[1] holding the value of randomly_generate_curve25519_point(1 + offset),
+                        `generator[0]` holding the value of `randomly_generate_curve25519_point(0 + offset)`,
+                        `generator[1]` holding the value of `randomly_generate_curve25519_point(1 + offset)`,
                         and so on.
 
 # Asserts
 
-If the data.len() value is different from the commitments.len() value.
+If the `data.len()` value is different from the `commitments.len()` value.
 
 # Panics
 

--- a/src/compute/backend.rs
+++ b/src/compute/backend.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 use std::sync::Once;
 
-/// struct to hold configuration values about the chosen backend
+/// Struct to hold configuration values about the chosen backend.
 pub struct BackendConfig {
-    /// The total number of precomputed values to be generated
+    /// The total number of precomputed values to be generated.
     pub num_precomputed_generators: u64,
 }
 

--- a/src/compute/generators.rs
+++ b/src/compute/generators.rs
@@ -42,7 +42,7 @@ pub fn get_curve25519_generators(generators: &mut [RistrettoPoint], offset_gener
 
 #[doc = include_str!("../../docs/commitments/get_one_curve25519_commit.md")]
 ///
-/// # Example - Getting the i-th One Commit
+/// # Example - Getting the `n`-th One Commit
 /// ```no_run
 #[doc = include_str!("../../examples/get_one_commit.rs")]
 /// ```

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! High-Level Rust wrapper for the blitzar-sys crate.
+//! commitment and generator computation
 
 mod backend;
 pub use backend::{init_backend, init_backend_with_config, BackendConfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,45 +23,44 @@
 //!   </picture>
 //! </p>
 //! <p align="center">
-//!   <a href="">
+//!   <a href="https://crates.io/crates/blitzar">
+//!     <img alt="crates.io version" src="https://img.shields.io/crates/v/blitzar.svg">
+//!   </a>
+//!   <a href="https://github.com/spaceandtimelabs/blitzar-rs">
 //!     <img alt="Build states" src="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml/badge.svg">
+//!   </a>
+//!   <a href="https://docs.rs/crate/blitzar/">
+//!     <img alt="docs.rs" src="https://img.shields.io/docsrs/blitzar">
 //!   </a>
 //!   <a href="#badge">
 //!     <img alt="semantic-release: conventional-commits" src="https://img.shields.io/badge/semantic--release-conventional--commits-blueviolet">
 //!   </a>
-//!   <a href="#badge">
-//!     <img alt="docs" src="https://img.shields.io/badge/docs-passing-green">
-//!   </a>
 //! </p>
 //!
-//! High-Level Rust wrapper for the blitzar-sys crate
-//! For the rust sys-crate and the C++ repo, check
+//! High-Level Rust wrapper for the `blitzar-sys` crate.
+//! For the Rust sys-crate and the C++ repo, check
 //! [here](https://github.com/spaceandtimelabs/blitzar).
 //!
-//!## Considerations:
+//! ## Considerations:
 //!
-//!1. The current library only supports `x86_64` architectures and only the linux operating system.
-//!2. Until this point, the library was tested only in the `ubuntu20.04` linux environment.
-//!3. Consider using `docker` or a virtual machine.
-//!4. You must have the latest rust environment installed in your linux machine. Download [here](https://www.rust-lang.org/tools/install).
+//! 1. The current library only supports `x86_64` architectures and only the Linux operating system.
+//! 2. The library was tested in the `ubuntu22.04` Linux environment.
+//! 3. Consider using `docker` or a virtual machine.
+//! 4. You must have the latest Rust environment installed in your Linux machine. Download [here](https://www.rust-lang.org/tools/install).
 //!
 
 //! ## Use
-
+//!
 //! Add the following two lines to your `Cargo.toml` file:
-
 //! ```text
-//! [dependencies.blitzar]
-//! path = "/path/to/directory/blitzar/"
+//! [dependencies]
+//! blitzar = <version_number>
 //! ```
-
-//! Don't forget to substitute this `path` with the correct location of your `blitzar` directory.
-
+//!
 //! Import the necessary modules to your rust code:
-
 //! ```text
 //! extern crate blitzar;
-
+//!
 //! use blitzar::sequence::*;
 //! use blitzar::compute::*;
 //! ```
@@ -71,7 +70,7 @@
 //!All the examples are located in the `examples/` directory. Each one has its own `.rs` file. To run some example, use the following command:
 //!
 //!```text
-//! cargo run --features <cpu | gpu> --example <example_name>
+//! cargo run --features <cpu|gpu> --example <example_name>
 //!```
 //!
 //! ## Tests

--- a/src/proof/inner_product.rs
+++ b/src/proof/inner_product.rs
@@ -18,7 +18,7 @@ use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 
-/// InnerProductProof construct.
+/// InnerProductProof construct
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InnerProductProof {
     pub(crate) l_vector: Vec<CompressedRistretto>,
@@ -27,14 +27,14 @@ pub struct InnerProductProof {
 }
 
 impl InnerProductProof {
-    /// Creates an inner product proof
+    /// Creates an inner product proof.
     ///
-    /// The proof is created with respect to the base G, provided by:
+    /// The proof is created with respect to the base `G`, provided by:
     ///
     /// ```text
     /// let np = 1ull << ceil(log2(n));
     /// let G = vec![RISTRETTO_BASEPOINT_POINT; np + 1];
-    /// crate::compute::get_curve25519_generators(G, generators_offset)`.
+    /// crate::compute::get_curve25519_generators(G, generators_offset)
     /// ```
     ///
     /// The `verifier` transcript is passed in as a parameter so that the
@@ -46,34 +46,34 @@ impl InnerProductProof {
     ///
     /// # Algorithm description
     ///
-    /// Initially, we compute G and Q = G\[np\], where np = 1ull << ceil(log2(n))
-    /// and G is zero-indexed.
+    /// Initially, we compute `G` and `Q = G[np]`, where `np = 1ull << ceil(log2(n))`
+    /// and `G` is zero-indexed.
     ///
-    /// The protocol consists of k = ceil(lg_2(n)) rounds, indexed by j = k - 1 , ... , 0.
+    /// The protocol consists of `k = ceil(lg_2(n))` rounds, indexed by `j = k - 1 , ... , 0`.
     ///
-    /// In the j-th round, the prover computes:
+    /// In the `j`-th round, the prover computes:
     ///
     /// ```text
-    /// a_lo = {a[0], a[1], ..., a[n / 2 - 1]}
+    /// a_lo = {a[0], a[1], ..., a[n/2 - 1]}
     /// a_hi = {a[n/2], a[n/2 + 1], ..., a[n - 1]}
-    /// b_lo = {b[0], b[1], ..., b[n / 2 - 1]}
+    /// b_lo = {b[0], b[1], ..., b[n/2 - 1]}
     /// b_hi = {b[n/2], b[n/2 + 1], ..., b[n - 1]}
-    /// G_lo = {G[0], G[1], ..., G[n / 2 - 1]}
+    /// G_lo = {G[0], G[1], ..., G[n/2 - 1]}
     /// G_hi = {G[n/2], G[n/2 + 1], ..., G[n-1]}
     ///
     /// l_vector[j] = <a_lo, G_hi> + <a_lo, b_hi> * Q
     /// r_vector[j] = <a_hi, G_lo> + <a_hi, b_lo> * Q
     /// ```
     ///
-    /// Note that if the `a` or `b` length is not a power of 2,
-    /// then `a` or `b` is padded with zeros until it has a power of 2.
-    /// G always has a power of 2 given how it is constructed.
+    /// Note that if the `a` or `b` length is not a power of `2`,
+    /// then `a` or `b` is padded with zeros until it has a power of `2`.
+    /// `G` always has a power of `2` given how it is constructed.
     ///
-    /// Then the prover sends l_vector\[j\] and r_vector\[j\] to the verifier,
+    /// Then the prover sends `l_vector[j]` and `r_vector[j]` to the verifier,
     /// and the verifier responds with a
-    /// challenge value u\[j\] <- Z_p (finite field of order p),
+    /// challenge value `u[j]` <- `Z_p` (finite field of order `p`),
     /// which is non-interactively simulated by
-    /// the input strobe-based transcript:
+    /// the input strobe-based transcript.
     ///
     /// ```text
     /// transcript.append("L", l_vector[j]);
@@ -82,31 +82,31 @@ impl InnerProductProof {
     /// u[j] = transcript.challenge_value("x");
     /// ```
     ///
-    /// Then the prover uses u\[j\] to compute
+    /// Then the prover uses `u[j]` to compute
     ///
     /// ```text
-    /// a = a_lo * u[j] + (u[j]^-1) * a_hi;
-    /// b = b_lo * (u[j]^-1) + u[j] * b_hi;
+    /// a = a_lo * u[j] + (u[j]^(-1)) * a_hi;
+    /// b = b_lo * (u[j]^(-1)) + u[j] * b_hi;
     /// ```
     ///
     /// Then, the prover and verifier both compute
     ///
     /// ```text
-    /// G = G_lo * (u[j]^-1) + u[j] * G_hi
+    /// G = G_lo * (u[j]^(-1)) + u[j] * G_hi
     ///
     /// n = n / 2;
     /// ```
     ///
-    /// and use these vectors (all of length 2^j) for the next round.
+    /// and use these vectors (all of length `2^j`) for the next round.
     ///
-    /// After the last (j = 0) round, the prover sends ap_value = a\[0\] to the verifier.
+    /// After the last (`j = 0`) round, the prover sends `ap_value = a[0]` to the verifier.
     ///
     /// # Arguments:
     ///
-    /// - transcript (in/out): a single strobe-based transcript
-    /// - a (in): array with non-zero length n
-    /// - b (in): array with non-zero length n
-    /// - generators_offset (in): offset used to fetch the bases
+    /// - `transcript` (in/out): a single strobe-based transcript
+    /// - `a` (in): array with non-zero length `n`
+    /// - `b` (in): array with non-zero length `n`
+    /// - `generators_offset` (in): offset used to fetch the bases
     pub fn create(
         transcript: &mut Transcript,
         a: &[Scalar],
@@ -155,9 +155,9 @@ impl InnerProductProof {
         }
     }
 
-    /// Verifies an inner product proof
+    /// Verifies an inner product proof.
     ///
-    /// The proof is verified with respect to the base G, provided by:
+    /// The proof is verified with respect to the base `G`, provided by:
     ///
     /// ```text
     /// let np = 1ull << ceil(log2(n));
@@ -170,14 +170,14 @@ impl InnerProductProof {
     ///
     /// # Arguments:
     ///
-    /// - transcript (in/out): a single strobe-based transcript
-    /// - a_commit (in): a single ristretto point,
-    ///                  represented by <a, G> (the inner product of the two vectors)
-    /// - product (in): a single scalar, represented by <a, b>,
+    /// - `transcript` (in/out): a single strobe-based transcript
+    /// - `a_commit` (in): a single Ristretto point,
+    ///                  represented by `<a, G>` (the inner product of the two vectors)
+    /// - `product` (in): a single scalar, represented by `<a, b>`,
     ///                 the inner product of the two vectors `a` and `b` used by
     ///                 `InnerProductProof::create(...)`
-    /// - b (in): array with non-zero length n, the same one used by `InnerProductProof::create(...)`
-    /// - generators_offset (in): offset used to fetch the bases
+    /// - `b` (in): array with non-zero length `n`, the same one used by `InnerProductProof::create(...)`
+    /// - `generators_offset` (in): offset used to fetch the bases
     pub fn verify(
         &self,
         transcript: &mut Transcript,

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! High-Level Rust wrapper for the blitzar-sys crate proof primitives.
+//! proof primitives
 
 mod error;
 pub use error::ProofError;

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -12,34 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Wrapper of the data / scalar field elements
+//! data and scalar field elements for data table
 
 use blitzar_sys::sxt_sequence_descriptor;
 
-/// This `Sequence` stores the slice view
-/// of a contiguous column data table.
+/// Stores the slice view of a contiguous column data table.
+///
 /// It doesn't matter how the data is represented.
 /// The only thing that matters is that
 /// the column table is contiguous in memory,
 /// and that the structure holding the memory
 /// can be represented as a slice view
-/// of u8 elements. Slices of primitive types
+/// of `u8` elements. Slices of primitive types
 /// automatically can be cast to this kind of
 /// slice view, by using `From` trait.
 #[derive(Copy, Clone)]
 pub struct Sequence<'a> {
     /// Represents a slice
     /// view of any region of memory
-    /// converted to a u8 slice view.
+    /// converted to a `u8` slice view.
     ///
     /// For doing the conversion from
     /// an arbitrary slice array to a
-    /// u8 slice array, we use the unsafe from_raw_parts.
+    /// `u8` slice array, we use the `unsafe from_raw_parts`.
     data_slice: &'a [u8],
 
     /// Represents the total number of
     /// bytes of each element encoded in the
-    /// `data_slice` view
+    /// `data_slice` view.
     ///
     /// During computations, this field is used to infer the total
     /// amount of `rows` in the `data_slice`, using for that the formula:
@@ -51,11 +51,11 @@ pub struct Sequence<'a> {
     /// and the `element_size` value are properly defined. For instance,
     /// you must secure that for:
     ///
-    /// - u8 data slice types: `element_size = std::mem::size_of::<u8>()`
-    /// - u16 data slice types: `element_size = std::mem::size_of::<u16>()`
-    /// - u32 data slice types: `element_size = std::mem::size_of::<u32>()`
-    /// - u64 data slice types: `element_size = std::mem::size_of::<u64>()`
-    /// - u128 data slice types: `element_size = std::mem::size_of::<u128>()`
+    /// - `u8` data slice types: `element_size = std::mem::size_of::<u8>()`
+    /// - `u16` data slice types: `element_size = std::mem::size_of::<u16>()`
+    /// - `u32` data slice types: `element_size = std::mem::size_of::<u32>()`
+    /// - `u64` data slice types: `element_size = std::mem::size_of::<u64>()`
+    /// - `u128` data slice types: `element_size = std::mem::size_of::<u128>()`
     element_size: usize,
 
     /// Represents whether the data slice should be interpreted
@@ -64,12 +64,12 @@ pub struct Sequence<'a> {
 }
 
 impl<'a> Sequence<'a> {
-    /// Returns the number of elements in the Dense Sequence
+    /// Returns the number of elements in the Dense Sequence.
     pub fn len(&self) -> usize {
         self.data_slice.len() / self.element_size
     }
 
-    /// Returns true if the sequence is empty, false otherwise
+    /// Returns `true` if the sequence is empty, `false` otherwise.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -78,8 +78,8 @@ impl<'a> Sequence<'a> {
     /// The `is_signed` parameter is used to determine whether the data is interpreted as a signed value or not.
     /// Several types are also supported via the `From` trait, which is preferred over this method.
     ///
-    /// The size of the elements in the slice must be between 1 and 16 bytes (inclusive) if `is_signed` is true,
-    /// and between 1 and 32 bytes (inclusive) if `is_signed` is false.
+    /// The size of the elements in the slice must be between `1` and `16` bytes (inclusive) if `is_signed` is true,
+    /// and between `1` and `32` bytes (inclusive) if `is_signed` is `false`.
     pub fn from_raw_parts<T>(slice: &'a [T], is_signed: bool) -> Self {
         let element_size = core::mem::size_of::<T>();
         if is_signed {


### PR DESCRIPTION
# Rationale for this change
This work updated the documentation formatting throughout the `blitzar-rs` project. This will make it easier to read the documents on crates.io. The majority of the updates are related to formatting. No sections have been rewritten.

# What changes are included in this PR?
- Documentation formatting is updated throughout.

# Are these changes tested?
Yes, using `cargo doc` locally.
