### PR TITLE
fix: limit hashtags to five in Cargo.toml file (PROOF-792)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "blitzar"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/spaceandtimelabs/blitzar-rs"
-keywords = ["gpu", "cryptography", "crypto", "ristretto", "curve25519", "ristretto255", "bls12-381", "bn254"]
+keywords = ["gpu-cryptography", "curve25519", "ristretto255", "bls12-381", "bn254"]
 description = "High-Level Rust wrapper for the blitzar-sys crate "
 exclude = [
     "**/.gitignore",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.1-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.3.2-green?style=flat&logo=nvidia">
     </a>
   </a>
 
@@ -117,9 +117,9 @@ To get a local copy up and running, consider the following steps.
 <details open>
 <summary>GPU backend prerequisites:</summary>
 
-* [Rust 1.69.0](https://www.rust-lang.org/tools/install)
+* [Rust 1.71.1](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* Nvidia Toolkit Driver Version: >= 535.104.05 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* Nvidia Toolkit Driver Version: >= 545.23.08 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 
@@ -128,7 +128,7 @@ To get a local copy up and running, consider the following steps.
 
 You'll need the following requirements to run the environment:
 
-* [Rust 1.69.0](https://www.rust-lang.org/tools/install)
+* [Rust 1.71.1](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.3.2-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.2-green?style=flat&logo=nvidia">
     </a>
   </a>
 
@@ -119,7 +119,7 @@ To get a local copy up and running, consider the following steps.
 
 * [Rust 1.71.1](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* Nvidia Toolkit Driver Version: >= 545.23.08 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* Nvidia Toolkit Driver Version: >= 535.104.05 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 


### PR DESCRIPTION
# Rationale for this change
The last cargo release failed because there was more than five hashtags in the `Cargo.toml` file. This work limits the hashtags to five and updates the CUDA toolkit and Rust versions to match the Docker image.

# What changes are included in this PR?
- The hashtag list in `Cargo.toml` is limited to five hashtags.
- The CUDA toolkit version is updated to `12.2` in the README.md to match Docker image version.
- Update Rust version to `1.71.1` to match Docker image version.

# Are these changes tested?
Yes, locally, but not on crates.io.