### PR TITLE
build: install zip during release workflow (PROOF-794)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           node-version: "18.x"
 
+      - name: Install zip
+        run: sudo apt-get update && sudo apt-get install -y zip
+
       - name: Semantic Release
         run: |
           npm install semantic-release


### PR DESCRIPTION
# Rationale for this change
The release workflow failed when using the new Docker container, which is based off of `Rust:1.76.0`, because `zip` was not installed. [See error](https://github.com/spaceandtimelabs/blitzar-rs/actions/runs/7975069426/job/21772508619).

This work adds a step inside the release workflow that installs `zip`.

# What changes are included in this PR?
- `zip` is now installed as part of the release workflow.

# Are these changes tested?
No. I'm not sure how to test the release workflow locally.