### PR TITLE
ci: update runner to be hosted by Github (PROOF-863)

### DIFF
--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-code:
     name: Check Code
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     steps:
       - name: Checkout Code Format
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
 
   clippy-code:
     name: Clippy Code
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
 
   test-cpu:
     name: Test the CPU backend
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
 
   test-gpu:
     name: Test the GPU backend
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
# Rationale for this change
CI currently runs on a self-hosted runner. Github now offers runners with access to GPUs. This work updated the CI to be run with Github's self hosted runner.

# What changes are included in this PR?
- The runner is updated to use Github.

# Are these changes tested?
Yes
