### PR TITLE
feat: expose new multi-exponentiation api (PROOF-831)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
-blitzar-sys = { version = "1.55.0" }
+blitzar-sys = { version = "1.56.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0", optional = true }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
-blitzar-sys = { version = "1.15.1" }
+blitzar-sys = { version = "1.54.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
-blitzar-sys = { version = "1.54.0" }
+blitzar-sys = { version = "1.55.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/blitzar"
 ark-bls12-381 = { version = "0.4.0" }
 ark-bn254 = { version = "0.4.0" }
 ark-ec = { version = "0.4.0" }
-ark-ff = { version = "0.4.0", optional = true }
+ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
 blitzar-sys = { version = "1.54.0" }
@@ -38,7 +38,6 @@ harness = false
 name = "blitzar_benchmarks"
 
 [features]
-arkworks = ["dep:ark-ff"]
 cpu = []
 default = ["gpu"]
 gpu = []

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -1,6 +1,4 @@
-use ark_bls12_381::G1Projective;
-use ark_bn254::G1Projective as bn254_g1_projective;
-use ark_ec::CurveGroup;
+use ark_ec::short_weierstrass::Projective;
 use curve25519_dalek::ristretto::RistrettoPoint;
 
 pub trait Curve {
@@ -13,14 +11,14 @@ impl Curve for RistrettoPoint {
     }
 }
 
-impl Curve for G1Projective {
+impl Curve for Projective<ark_bls12_381::g1::Config> {
     fn curve_id() -> u32 {
         blitzar_sys::SXT_CURVE_BLS_381
     }
 }
 
-// impl Curve for bn254_g1_projective {
-//     fn curve_id() -> u32 {
-//         blitzar_sys::SXT_CURVE_BN_254
-//     }
-// }
+impl Curve for Projective<ark_bn254::g1::Config> {
+    fn curve_id() -> u32 {
+        blitzar_sys::SXT_CURVE_BN_254
+    }
+}

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -1,5 +1,6 @@
-use ark_bls12_381::G1Affine;
-use ark_bn254::G1Affine as bn254_g1_affine;
+use ark_bls12_381::G1Projective;
+use ark_bn254::G1Projective as bn254_g1_projective;
+use ark_ec::CurveGroup;
 use curve25519_dalek::ristretto::RistrettoPoint;
 
 pub trait Curve {
@@ -11,3 +12,15 @@ impl Curve for RistrettoPoint {
         blitzar_sys::SXT_CURVE_RISTRETTO255
     }
 }
+
+impl Curve for G1Projective {
+    fn curve_id() -> u32 {
+        blitzar_sys::SXT_CURVE_BLS_381
+    }
+}
+
+// impl Curve for bn254_g1_projective {
+//     fn curve_id() -> u32 {
+//         blitzar_sys::SXT_CURVE_BN_254
+//     }
+// }

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -1,5 +1,6 @@
-use ark_ec::short_weierstrass::Projective;
 use curve25519_dalek::ristretto::RistrettoPoint;
+use crate::compute::ElementP2;
+
 
 pub trait Curve {
     fn curve_id() -> u32;
@@ -11,13 +12,13 @@ impl Curve for RistrettoPoint {
     }
 }
 
-impl Curve for Projective<ark_bls12_381::g1::Config> {
+impl Curve for ElementP2<ark_bls12_381::g1::Config> {
     fn curve_id() -> u32 {
         blitzar_sys::SXT_CURVE_BLS_381
     }
 }
 
-impl Curve for Projective<ark_bn254::g1::Config> {
+impl Curve for ElementP2<ark_bn254::g1::Config> {
     fn curve_id() -> u32 {
         blitzar_sys::SXT_CURVE_BN_254
     }

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -1,0 +1,13 @@
+use ark_bls12_381::G1Affine;
+use ark_bn254::G1Affine as bn254_g1_affine;
+use curve25519_dalek::ristretto::RistrettoPoint;
+
+pub trait Curve {
+    fn curve_id() -> u32;
+}
+
+impl Curve for RistrettoPoint {
+    fn curve_id() -> u32 {
+        blitzar_sys::SXT_CURVE_RISTRETTO255
+    }
+}

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -1,6 +1,5 @@
-use curve25519_dalek::ristretto::RistrettoPoint;
 use crate::compute::ElementP2;
-
+use curve25519_dalek::ristretto::RistrettoPoint;
 
 pub trait Curve {
     fn curve_id() -> u32;

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -1,7 +1,7 @@
-use std::convert::{From, Into};
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
-use ark_std::{One, Zero};
 use ark_ff::fields::Field;
+use ark_std::{One, Zero};
+use std::convert::{From, Into};
 
 /// TODO(rnburn): doc me
 #[derive(Clone)]
@@ -28,10 +28,14 @@ impl<P: SWCurveConfig> Default for ElementP2<P> {
 
 impl<P: SWCurveConfig> From<Affine<P>> for ElementP2<P> {
     fn from(pt: Affine<P>) -> Self {
-        Self{
+        Self {
             x: pt.x,
             y: pt.y,
-            z: if pt.infinity { P::BaseField::zero() } else { P::BaseField::one() },
+            z: if pt.infinity {
+                P::BaseField::zero()
+            } else {
+                P::BaseField::one()
+            },
         }
     }
 }
@@ -39,14 +43,14 @@ impl<P: SWCurveConfig> From<Affine<P>> for ElementP2<P> {
 impl<P: SWCurveConfig> Into<Affine<P>> for ElementP2<P> {
     fn into(self) -> Affine<P> {
         if self.z.is_zero() {
-            return Affine::<P>{
+            return Affine::<P> {
                 x: P::BaseField::zero(),
                 y: P::BaseField::zero(),
                 infinity: true,
-            }
-        } 
+            };
+        }
         let z_inv = self.z.inverse().unwrap();
-        Affine::<P>{
+        Affine::<P> {
             x: self.x * z_inv,
             y: self.y * z_inv,
             infinity: false,

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -1,0 +1,4 @@
+/// TODO(rnburn): doc me
+pub struct ElementP2 {
+}
+

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -1,4 +1,26 @@
+use std::convert::From;
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig, Projective};
+use ark_std::{One, Zero};
+
 /// TODO(rnburn): doc me
-pub struct ElementP2 {
+pub struct ElementP2<P: SWCurveConfig> {
+    /// TODO(rnburn): doc me
+    pub x: P::BaseField,
+
+    /// TODO(rnburn): doc me
+    pub y: P::BaseField,
+
+    /// TODO(rnburn): doc me
+    pub z: P::BaseField,
 }
 
+impl<P: SWCurveConfig> From<Projective<P>> for ElementP2<P> {
+    fn from(pt: Projective<P>) -> Self {
+        let pt = Affine::<P>::from(pt);
+        Self{
+            x: pt.x,
+            y: pt.y,
+            z: if pt.infinity { P::BaseField::zero() } else { P::BaseField::one() },
+        }
+    }
+}

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -1,7 +1,7 @@
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::fields::Field;
 use ark_std::{One, Zero};
-use std::convert::{From, Into};
+use std::convert::From;
 
 /// TODO(rnburn): doc me
 #[derive(Clone)]
@@ -54,19 +54,19 @@ impl<P: SWCurveConfig> From<&Affine<P>> for ElementP2<P> {
     }
 }
 
-impl<P: SWCurveConfig> Into<Affine<P>> for ElementP2<P> {
-    fn into(self) -> Affine<P> {
-        if self.z.is_zero() {
+impl<P: SWCurveConfig> From<ElementP2<P>> for Affine<P> {
+    fn from(pt: ElementP2<P>) -> Self {
+        if pt.z.is_zero() {
             return Affine::<P> {
                 x: P::BaseField::zero(),
                 y: P::BaseField::zero(),
                 infinity: true,
             };
         }
-        let z_inv = self.z.inverse().unwrap();
+        let z_inv = pt.z.inverse().unwrap();
         Affine::<P> {
-            x: self.x * z_inv,
-            y: self.y * z_inv,
+            x: pt.x * z_inv,
+            y: pt.y * z_inv,
             infinity: false,
         }
     }

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -33,15 +33,7 @@ impl<P: SWCurveConfig> Default for ElementP2<P> {
 
 impl<P: SWCurveConfig> From<Affine<P>> for ElementP2<P> {
     fn from(pt: Affine<P>) -> Self {
-        Self {
-            x: pt.x,
-            y: pt.y,
-            z: if pt.infinity {
-                P::BaseField::zero()
-            } else {
-                P::BaseField::one()
-            },
-        }
+        ElementP2::<P>::from(&pt)
     }
 }
 
@@ -61,6 +53,12 @@ impl<P: SWCurveConfig> From<&Affine<P>> for ElementP2<P> {
 
 impl<P: SWCurveConfig> From<ElementP2<P>> for Affine<P> {
     fn from(pt: ElementP2<P>) -> Self {
+        Affine::<P>::from(&pt)
+    }
+}
+
+impl<P: SWCurveConfig> From<&ElementP2<P>> for Affine<P> {
+    fn from(pt: &ElementP2<P>) -> Self {
         if pt.z.is_zero() {
             return Affine::<P> {
                 x: P::BaseField::zero(),

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -40,6 +40,20 @@ impl<P: SWCurveConfig> From<Affine<P>> for ElementP2<P> {
     }
 }
 
+impl<P: SWCurveConfig> From<&Affine<P>> for ElementP2<P> {
+    fn from(pt: &Affine<P>) -> Self {
+        Self {
+            x: pt.x,
+            y: pt.y,
+            z: if pt.infinity {
+                P::BaseField::zero()
+            } else {
+                P::BaseField::one()
+            },
+        }
+    }
+}
+
 impl<P: SWCurveConfig> Into<Affine<P>> for ElementP2<P> {
     fn into(self) -> Affine<P> {
         if self.z.is_zero() {

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -4,6 +4,7 @@ use ark_std::{One, Zero};
 use ark_ff::fields::Field;
 
 /// TODO(rnburn): doc me
+#[derive(Clone)]
 pub struct ElementP2<P: SWCurveConfig> {
     /// TODO(rnburn): doc me
     pub x: P::BaseField,
@@ -13,6 +14,16 @@ pub struct ElementP2<P: SWCurveConfig> {
 
     /// TODO(rnburn): doc me
     pub z: P::BaseField,
+}
+
+impl<P: SWCurveConfig> Default for ElementP2<P> {
+    fn default() -> Self {
+        Self {
+            x: P::BaseField::zero(),
+            y: P::BaseField::zero(),
+            z: P::BaseField::zero(),
+        }
+    }
 }
 
 impl<P: SWCurveConfig> From<Affine<P>> for ElementP2<P> {

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -3,16 +3,21 @@ use ark_ff::fields::Field;
 use ark_std::{One, Zero};
 use std::convert::From;
 
-/// TODO(rnburn): doc me
+/// Projective form for a short Weierstrass curve element.
+///
+/// A point (x, y, z) represents the affine point (x / z, y / z) or
+/// the identity if z == 0
 #[derive(Clone)]
 pub struct ElementP2<P: SWCurveConfig> {
-    /// TODO(rnburn): doc me
+    /// (x, z) maps to the affine point x / z
     pub x: P::BaseField,
 
-    /// TODO(rnburn): doc me
+    /// (y, z) maps to the affine point y / z
     pub y: P::BaseField,
 
-    /// TODO(rnburn): doc me
+    /// divisor to convert to affine points
+    ///
+    /// if z == 0, the point represents the identity element
     pub z: P::BaseField,
 }
 

--- a/src/compute/element_p2.rs
+++ b/src/compute/element_p2.rs
@@ -1,6 +1,7 @@
-use std::convert::From;
-use ark_ec::short_weierstrass::{Affine, SWCurveConfig, Projective};
+use std::convert::{From, Into};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_std::{One, Zero};
+use ark_ff::fields::Field;
 
 /// TODO(rnburn): doc me
 pub struct ElementP2<P: SWCurveConfig> {
@@ -14,13 +15,30 @@ pub struct ElementP2<P: SWCurveConfig> {
     pub z: P::BaseField,
 }
 
-impl<P: SWCurveConfig> From<Projective<P>> for ElementP2<P> {
-    fn from(pt: Projective<P>) -> Self {
-        let pt = Affine::<P>::from(pt);
+impl<P: SWCurveConfig> From<Affine<P>> for ElementP2<P> {
+    fn from(pt: Affine<P>) -> Self {
         Self{
             x: pt.x,
             y: pt.y,
             z: if pt.infinity { P::BaseField::zero() } else { P::BaseField::one() },
+        }
+    }
+}
+
+impl<P: SWCurveConfig> Into<Affine<P>> for ElementP2<P> {
+    fn into(self) -> Affine<P> {
+        if self.z.is_zero() {
+            return Affine::<P>{
+                x: P::BaseField::zero(),
+                y: P::BaseField::zero(),
+                infinity: true,
+            }
+        } 
+        let z_inv = self.z.inverse().unwrap();
+        Affine::<P>{
+            x: self.x * z_inv,
+            y: self.y * z_inv,
+            infinity: false,
         }
     }
 }

--- a/src/compute/element_p2_test.rs
+++ b/src/compute/element_p2_test.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+use ark_bls12_381::G1Affine;
+use ark_std::UniformRand;
+
+#[test]
+fn we_can_convert_between_different_point_representations() {
+    // we handle zero
+    let e1 = G1Affine::identity();
+    let e2 = ElementP2::from(e1);
+    let e1p = G1Affine::from(e2);
+    assert_eq!(e1, e1p);
+
+    // we handle a random point
+    let mut rng = ark_std::test_rng();
+    let e1 = G1Affine::rand(&mut rng);
+    let e2 = ElementP2::from(e1);
+    let e1p = G1Affine::from(e2);
+    assert_eq!(e1, e1p);
+}

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -19,7 +19,7 @@ impl<T: Curve> MsmHandle<T> {
                 generators.len() as u32,
             );
             Self {
-                handle: handle,
+                handle,
                 phantom: PhantomData,
             }
         }
@@ -35,8 +35,8 @@ impl<T: Curve> MsmHandle<T> {
                 res.as_ptr() as *mut std::ffi::c_void,
                 self.handle,
                 element_num_bytes,
-                num_outputs as u32,
-                n as u32,
+                num_outputs,
+                n,
                 scalars.as_ptr(),
             );
         }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -11,7 +11,6 @@ pub struct MsmHandle<T: Curve> {
 impl<T: Curve> MsmHandle<T> {
     /// TODO(rnburn): document me
     pub fn new(generators: &[T]) -> Self {
-        println!("curve_id = {}", T::curve_id());
         unsafe {
             let handle = blitzar_sys::sxt_multiexp_handle_new(
                 T::curve_id(),

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -10,7 +10,7 @@ pub struct MsmHandle<T: Curve> {
 }
 
 impl<T: Curve> MsmHandle<T> {
-    /// new handel from the specified generators.
+    /// new handle from the specified generators.
     ///
     /// Note: any MSMs computed with the handle must have length less than or equal
     /// to the number of generators used to create the handle.

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -43,7 +43,7 @@ impl<T: Curve> MsmHandle<T> {
     ///
     /// is an array of scalars of element_num_bytes each.
     ///
-    /// If msm is called with the slice of scalars of element_num_bytes * m * n
+    /// If msm is called with the slice of scalars of size element_num_bytes * m * n
     /// defined by
     ///
     ///    scalars = [s_11, s_21, ..., s_m1, s_12, s_22, ..., s_m2, ..., s_mn ]

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -3,14 +3,17 @@ use super::backend::init_backend;
 use crate::compute::Curve;
 use std::marker::PhantomData;
 
-/// TODO(rnburn): document me
+/// Handle to compute multi-scalar multiplications (MSMs) with pre-specified generators
 pub struct MsmHandle<T: Curve> {
     handle: *mut blitzar_sys::sxt_multiexp_handle,
     phantom: PhantomData<T>,
 }
 
 impl<T: Curve> MsmHandle<T> {
-    /// TODO(rnburn): document me
+    /// new handel from the specified generators.
+    ///
+    /// Note: any MSMs computed with the handle must have length less than or equal
+    /// to the number of generators used to create the handle.
     pub fn new(generators: &[T]) -> Self {
         init_backend();
 

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -9,10 +9,26 @@ pub struct MsmHandle<T: Curve> {
 }
 
 impl<T: Curve> MsmHandle<T> {
-    fn new(generators: &[T] ) -> Self {
-        Self{
-            handle: std::ptr::null_mut(),
-            phantom: PhantomData,
+    /// TODO(rnburn): document me
+    pub fn new(generators: &[T] ) -> Self {
+        unsafe {
+          let handle =
+            blitzar_sys::sxt_multiexp_handle_new(
+                T::curve_id(),
+                generators.as_ptr() as *const std::ffi::c_void,
+                generators.len() as u32);
+            Self{
+                handle: handle,
+                phantom: PhantomData,
+            }
+        }
+    }
+}
+
+impl<T: Curve> Drop for MsmHandle<T> {
+    fn drop(&mut self) {
+        unsafe {
+          blitzar_sys::sxt_multiexp_handle_free(self.handle);
         }
     }
 }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -10,15 +10,15 @@ pub struct MsmHandle<T: Curve> {
 
 impl<T: Curve> MsmHandle<T> {
     /// TODO(rnburn): document me
-    pub fn new(generators: &[T] ) -> Self {
+    pub fn new(generators: &[T]) -> Self {
         println!("curve_id = {}", T::curve_id());
         unsafe {
-          let handle =
-            blitzar_sys::sxt_multiexp_handle_new(
+            let handle = blitzar_sys::sxt_multiexp_handle_new(
                 T::curve_id(),
                 generators.as_ptr() as *const std::ffi::c_void,
-                generators.len() as u32);
-            Self{
+                generators.len() as u32,
+            );
+            Self {
                 handle: handle,
                 phantom: PhantomData,
             }
@@ -37,7 +37,7 @@ impl<T: Curve> MsmHandle<T> {
                 element_num_bytes,
                 num_outputs as u32,
                 n as u32,
-                scalars.as_ptr()
+                scalars.as_ptr(),
             );
         }
     }
@@ -46,7 +46,7 @@ impl<T: Curve> MsmHandle<T> {
 impl<T: Curve> Drop for MsmHandle<T> {
     fn drop(&mut self) {
         unsafe {
-          blitzar_sys::sxt_multiexp_handle_free(self.handle);
+            blitzar_sys::sxt_multiexp_handle_free(self.handle);
         }
     }
 }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -11,6 +11,7 @@ pub struct MsmHandle<T: Curve> {
 impl<T: Curve> MsmHandle<T> {
     /// TODO(rnburn): document me
     pub fn new(generators: &[T] ) -> Self {
+        println!("curve_id = {}", T::curve_id());
         unsafe {
           let handle =
             blitzar_sys::sxt_multiexp_handle_new(

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -23,6 +23,23 @@ impl<T: Curve> MsmHandle<T> {
             }
         }
     }
+
+    /// TODO(rnburn): document me
+    pub fn msm(&self, res: &mut [T], element_num_bytes: u32, scalars: &[u8]) {
+        let num_outputs = res.len() as u32;
+        assert!(scalars.len() as u32 % (num_outputs * element_num_bytes) == 0);
+        let n = scalars.len() as u32 / (num_outputs * element_num_bytes);
+        unsafe {
+            blitzar_sys::sxt_fixed_multiexponentiation(
+                res.as_ptr() as *mut std::ffi::c_void,
+                self.handle,
+                element_num_bytes,
+                num_outputs as u32,
+                n as u32,
+                scalars.as_ptr()
+            );
+        }
+    }
 }
 
 impl<T: Curve> Drop for MsmHandle<T> {

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -1,0 +1,16 @@
+// use super::backend::init_backend;
+use crate::compute::Curve;
+use std::marker::PhantomData;
+
+/// TODO(rnburn): document me
+pub struct MsmHandle<T: Curve> {
+    phantom: PhantomData<T>,
+}
+
+impl<T: Curve> MsmHandle<T> {
+    fn new(generators: &[T] ) -> Self {
+        Self{
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -4,12 +4,14 @@ use std::marker::PhantomData;
 
 /// TODO(rnburn): document me
 pub struct MsmHandle<T: Curve> {
+    handle: *mut blitzar_sys::sxt_multiexp_handle,
     phantom: PhantomData<T>,
 }
 
 impl<T: Curve> MsmHandle<T> {
     fn new(generators: &[T] ) -> Self {
         Self{
+            handle: std::ptr::null_mut(),
             phantom: PhantomData,
         }
     }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -10,7 +10,7 @@ pub struct MsmHandle<T: Curve> {
 }
 
 impl<T: Curve> MsmHandle<T> {
-    /// new handle from the specified generators.
+    /// New handle from the specified generators.
     ///
     /// Note: any MSMs computed with the handle must have length less than or equal
     /// to the number of generators used to create the handle.
@@ -30,7 +30,31 @@ impl<T: Curve> MsmHandle<T> {
         }
     }
 
-    /// TODO(rnburn): document me
+    /// Compute an MSM using pre-specified generators.
+    ///
+    /// Suppose g_1, ..., g_n are pre-specified generators and
+    ///
+    ///    s_11, s_12, ..., s_1n
+    ///    s_21, s_22, ..., s_2n
+    ///    .
+    ///    .   .
+    ///    .       .
+    ///    s_m1, sm2, ..., s_mn
+    ///
+    /// is an array of scalars of element_num_bytes each.
+    ///
+    /// If msm is called with the slice of scalars of element_num_bytes * m * n
+    /// defined by
+    ///
+    ///    scalars = [s_11, s_21, ..., s_m1, s_12, s_22, ..., s_m2, ..., s_mn ]
+    ///
+    /// then res will contain the MSM result
+    ///
+    ///    res[0] = s_11 * g_1 + s_12 * g_2 + ... + s_1n * g_n
+    ///       .
+    ///       .
+    ///       .
+    ///    res[m-1] = s_m1 * g_1 + s_12 * g_2 + ... + s_mn * g_n
     pub fn msm(&self, res: &mut [T], element_num_bytes: u32, scalars: &[u8]) {
         let num_outputs = res.len() as u32;
         assert!(scalars.len() as u32 % (num_outputs * element_num_bytes) == 0);

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -1,4 +1,5 @@
 // use super::backend::init_backend;
+use super::backend::init_backend;
 use crate::compute::Curve;
 use std::marker::PhantomData;
 
@@ -11,6 +12,8 @@ pub struct MsmHandle<T: Curve> {
 impl<T: Curve> MsmHandle<T> {
     /// TODO(rnburn): document me
     pub fn new(generators: &[T]) -> Self {
+        init_backend();
+
         unsafe {
             let handle = blitzar_sys::sxt_multiexp_handle_new(
                 T::curve_id(),

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -17,9 +17,13 @@ fn we_can_compute_msms_using_a_single_generator() {
     // create handle
     let handle = MsmHandle::new(&generators);
 
-    // try different multiexponentiations
+    // 1 * g
     let scalars: Vec<u8> = vec![1];
-
     handle.msm(&mut res, 1, &scalars);
     assert_eq!(res[0], generators[0]);
+
+    // 2 * g
+    let scalars: Vec<u8> = vec![2];
+    handle.msm(&mut res, 1, &scalars);
+    assert_eq!(res[0], generators[0] + generators[0]);
 }

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use ark_std::UniformRand;
+use ark_serialize::CanonicalSerialize;
 use ark_bls12_381::{G1Projective};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use rand_core::OsRng;
@@ -30,6 +31,7 @@ fn we_can_compute_msms_using_a_single_generator() {
     assert_eq!(res[0], generators[0] + generators[0]);
 }
 
+/*
 #[test]
 fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let mut rng = ark_std::test_rng();
@@ -46,12 +48,26 @@ fn we_can_compute_msms_using_a_single_generator_bls12_381() {
 
     // 1 * g
     let scalars: Vec<u8> = vec![1];
+    println!("E size = {}", std::mem::size_of::<G1Projective>());
+    println!("res = {}", res[0]);
     handle.msm(&mut res, 1, &scalars);
     println!("res = {}", res[0]);
+
+    // let mut bytes1 = Vec::new();
+    // res[0]
+    //     .serialize_compressed(&mut bytes1)
+    //     .unwrap();
+    //
+    // let mut bytes2 = Vec::new();
+    // generators[0]
+    //     .serialize_compressed(&mut bytes2)
+    //     .unwrap();
+
+    // assert_eq!(bytes1, bytes2);
     assert_eq!(res[0], generators[0]);
 
     // 2 * g
-    let scalars: Vec<u8> = vec![2];
-    handle.msm(&mut res, 1, &scalars);
-    assert_eq!(res[0], generators[0] + generators[0]);
-}
+    // let scalars: Vec<u8> = vec![2];
+    // handle.msm(&mut res, 1, &scalars);
+    // assert_eq!(res[0], generators[0] + generators[0]);
+}*/

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -1,0 +1,25 @@
+use super::*;
+
+use curve25519_dalek::ristretto::RistrettoPoint;
+use rand_core::OsRng;
+
+#[test]
+fn we_can_compute_msms_using_a_single_generator() {
+    let mut rng = OsRng;
+
+    let mut res = vec![RistrettoPoint::default(); 1];
+
+    // randomly obtain the generator points
+    let generators: Vec<RistrettoPoint> = (0..1)
+        .map(|_| RistrettoPoint::random(&mut rng))
+        .collect();
+
+    // create handle
+    let handle = MsmHandle::new(&generators);
+
+    // try different multiexponentiations
+    let scalars: Vec<u8> = vec![1];
+
+    handle.msm(&mut res, 1, &scalars);
+    assert_eq!(res[0], generators[0]);
+}

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -31,6 +31,25 @@ fn we_can_compute_msms_using_a_single_generator() {
 }
 
 #[test]
+fn we_can_compute_msms_using_multiple_generator() {
+    let mut rng = OsRng;
+
+    let mut res = vec![RistrettoPoint::default(); 1];
+
+    // randomly obtain the generator points
+    let generators: Vec<RistrettoPoint> =
+        (0..2).map(|_| RistrettoPoint::random(&mut rng)).collect();
+
+    // create handle
+    let handle = MsmHandle::new(&generators);
+
+    // g[0] + 2 * g[1]
+    let scalars: Vec<u8> = vec![1, 2];
+    handle.msm(&mut res, 1, &scalars);
+    assert_eq!(res[0], generators[0] + generators[1] + generators[1]);
+}
+
+#[test]
 fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let mut rng = ark_std::test_rng();
 
@@ -41,16 +60,9 @@ fn we_can_compute_msms_using_a_single_generator_bls12_381() {
         (0..1).map(|_| G1Affine::rand(&mut rng).into()).collect();
 
     let g: G1Affine = generators[0].clone().into();
-    // println!("g = {}", generators[0]);
 
     // create handle
     let handle = MsmHandle::new(&generators);
-
-    // 1 * g
-    let scalars: Vec<u8> = vec![1];
-    handle.msm(&mut res, 1, &scalars);
-    let r: G1Affine = res[0].clone().into();
-    assert_eq!(r, g);
 
     // 2 * g
     let scalars: Vec<u8> = vec![2];

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -1,10 +1,10 @@
 use super::*;
 
 use ark_std::UniformRand;
-use ark_serialize::CanonicalSerialize;
-use ark_bls12_381::{G1Projective};
+use ark_bls12_381::{G1Affine};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use rand_core::OsRng;
+use crate::compute::ElementP2;
 
 #[test]
 fn we_can_compute_msms_using_a_single_generator() {
@@ -31,43 +31,31 @@ fn we_can_compute_msms_using_a_single_generator() {
     assert_eq!(res[0], generators[0] + generators[0]);
 }
 
-/*
 #[test]
 fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let mut rng = ark_std::test_rng();
 
-    let mut res = vec![G1Projective::default(); 1];
+    let mut res = vec![ElementP2::<ark_bls12_381::g1::Config>::default(); 1];
 
     // randomly obtain the generator points
-    let generators: Vec<G1Projective> =
-        (0..1).map(|_| G1Projective::rand(&mut rng)).collect();
-    println!("g = {}", generators[0]);
+    let generators: Vec<ElementP2<ark_bls12_381::g1::Config>> =
+        (0..1).map(|_| G1Affine::rand(&mut rng).into()).collect();
+
+    let g : G1Affine = generators[0].clone().into();
+    // println!("g = {}", generators[0]);
 
     // create handle
     let handle = MsmHandle::new(&generators);
 
     // 1 * g
     let scalars: Vec<u8> = vec![1];
-    println!("E size = {}", std::mem::size_of::<G1Projective>());
-    println!("res = {}", res[0]);
     handle.msm(&mut res, 1, &scalars);
-    println!("res = {}", res[0]);
-
-    // let mut bytes1 = Vec::new();
-    // res[0]
-    //     .serialize_compressed(&mut bytes1)
-    //     .unwrap();
-    //
-    // let mut bytes2 = Vec::new();
-    // generators[0]
-    //     .serialize_compressed(&mut bytes2)
-    //     .unwrap();
-
-    // assert_eq!(bytes1, bytes2);
-    assert_eq!(res[0], generators[0]);
+    let r : G1Affine = res[0].clone().into();
+    assert_eq!(r, g);
 
     // 2 * g
-    // let scalars: Vec<u8> = vec![2];
-    // handle.msm(&mut res, 1, &scalars);
-    // assert_eq!(res[0], generators[0] + generators[0]);
-}*/
+    let scalars: Vec<u8> = vec![2];
+    handle.msm(&mut res, 1, &scalars);
+    let r : G1Affine = res[0].clone().into();
+    assert_eq!(r, g + g);
+}

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use ark_std::UniformRand;
+use ark_bls12_381::{G1Projective};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use rand_core::OsRng;
 
@@ -20,6 +22,32 @@ fn we_can_compute_msms_using_a_single_generator() {
     // 1 * g
     let scalars: Vec<u8> = vec![1];
     handle.msm(&mut res, 1, &scalars);
+    assert_eq!(res[0], generators[0]);
+
+    // 2 * g
+    let scalars: Vec<u8> = vec![2];
+    handle.msm(&mut res, 1, &scalars);
+    assert_eq!(res[0], generators[0] + generators[0]);
+}
+
+#[test]
+fn we_can_compute_msms_using_a_single_generator_bls12_381() {
+    let mut rng = ark_std::test_rng();
+
+    let mut res = vec![G1Projective::default(); 1];
+
+    // randomly obtain the generator points
+    let generators: Vec<G1Projective> =
+        (0..1).map(|_| G1Projective::rand(&mut rng)).collect();
+    println!("g = {}", generators[0]);
+
+    // create handle
+    let handle = MsmHandle::new(&generators);
+
+    // 1 * g
+    let scalars: Vec<u8> = vec![1];
+    handle.msm(&mut res, 1, &scalars);
+    println!("res = {}", res[0]);
     assert_eq!(res[0], generators[0]);
 
     // 2 * g

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -1,10 +1,10 @@
 use super::*;
 
+use crate::compute::ElementP2;
+use ark_bls12_381::G1Affine;
 use ark_std::UniformRand;
-use ark_bls12_381::{G1Affine};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use rand_core::OsRng;
-use crate::compute::ElementP2;
 
 #[test]
 fn we_can_compute_msms_using_a_single_generator() {
@@ -13,9 +13,8 @@ fn we_can_compute_msms_using_a_single_generator() {
     let mut res = vec![RistrettoPoint::default(); 1];
 
     // randomly obtain the generator points
-    let generators: Vec<RistrettoPoint> = (0..1)
-        .map(|_| RistrettoPoint::random(&mut rng))
-        .collect();
+    let generators: Vec<RistrettoPoint> =
+        (0..1).map(|_| RistrettoPoint::random(&mut rng)).collect();
 
     // create handle
     let handle = MsmHandle::new(&generators);
@@ -41,7 +40,7 @@ fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let generators: Vec<ElementP2<ark_bls12_381::g1::Config>> =
         (0..1).map(|_| G1Affine::rand(&mut rng).into()).collect();
 
-    let g : G1Affine = generators[0].clone().into();
+    let g: G1Affine = generators[0].clone().into();
     // println!("g = {}", generators[0]);
 
     // create handle
@@ -50,12 +49,12 @@ fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     // 1 * g
     let scalars: Vec<u8> = vec![1];
     handle.msm(&mut res, 1, &scalars);
-    let r : G1Affine = res[0].clone().into();
+    let r: G1Affine = res[0].clone().into();
     assert_eq!(r, g);
 
     // 2 * g
     let scalars: Vec<u8> = vec![2];
     handle.msm(&mut res, 1, &scalars);
-    let r : G1Affine = res[0].clone().into();
+    let r: G1Affine = res[0].clone().into();
     assert_eq!(r, g + g);
 }

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -50,6 +50,30 @@ fn we_can_compute_msms_using_multiple_generator() {
 }
 
 #[test]
+fn we_can_compute_msms_using_multiple_outputs() {
+    let mut rng = OsRng;
+
+    let mut res = vec![RistrettoPoint::default(); 2];
+
+    // randomly obtain the generator points
+    let generators: Vec<RistrettoPoint> =
+        (0..2).map(|_| RistrettoPoint::random(&mut rng)).collect();
+
+    // create handle
+    let handle = MsmHandle::new(&generators);
+
+    // g[0] + 2 * g[1]
+    // 3 * g[0] + g[1]
+    let scalars: Vec<u8> = vec![1, 3, 2, 1];
+    handle.msm(&mut res, 1, &scalars);
+    assert_eq!(res[0], generators[0] + generators[1] + generators[1]);
+    assert_eq!(
+        res[1],
+        generators[0] + generators[0] + generators[0] + generators[1]
+    );
+}
+
+#[test]
 fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let mut rng = ark_std::test_rng();
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -34,6 +34,8 @@ mod fixed_msm;
 pub use fixed_msm::{
     MsmHandle,
 };
+#[cfg(test)]
+mod fixed_msm_tests;
 
 mod generators;
 pub use generators::{get_curve25519_generators, get_one_curve25519_commit};

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -34,9 +34,7 @@ mod element_p2;
 pub use element_p2::ElementP2;
 
 mod fixed_msm;
-pub use fixed_msm::{
-    MsmHandle,
-};
+pub use fixed_msm::MsmHandle;
 #[cfg(test)]
 mod fixed_msm_tests;
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -30,6 +30,9 @@ pub use commitments::{
 #[cfg(test)]
 mod commitments_tests;
 
+mod element_p2;
+pub use element_p2::ElementP2;
+
 mod fixed_msm;
 pub use fixed_msm::{
     MsmHandle,

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -32,6 +32,8 @@ mod commitments_tests;
 
 mod element_p2;
 pub use element_p2::ElementP2;
+#[cfg(test)]
+mod element_p2_test;
 
 mod fixed_msm;
 pub use fixed_msm::MsmHandle;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -17,6 +17,9 @@
 mod backend;
 pub use backend::{init_backend, init_backend_with_config, BackendConfig};
 
+mod curve;
+use curve::Curve;
+
 mod commitments;
 pub use commitments::{
     compute_bls12_381_g1_commitments_with_generators,
@@ -26,6 +29,11 @@ pub use commitments::{
 
 #[cfg(test)]
 mod commitments_tests;
+
+mod fixed_msm;
+pub use fixed_msm::{
+    MsmHandle,
+};
 
 mod generators;
 pub use generators::{get_curve25519_generators, get_one_curve25519_commit};


### PR DESCRIPTION
# Rationale for this change

Add a minimal interface for computing MSMs using blitzar's new partition method algorithm.

The algorithm improves performance for the case of MSMs with fixed pre-specified generators caching precomputed sums.

I plan to follow up with PRs to add examples and extensions to make the interface more convenient.

# What changes are included in this PR?

* Adds a new MsmHandle struct for computing MSMs with fixed generators
* Adds an ElementP2 struct to correspond to how blitzar represents short Weierstrass curve elements.

# Are these changes tested?

Yes