### PR TITLE
feat!: extend MsmHandle to interoperate more easily with affine elements (PROOF-831)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ark-ec = { version = "0.4.0" }
 ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
+rayon = { version = "1.5" }
 blitzar-sys = { version = "1.56.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -1,7 +1,7 @@
 use crate::compute::ElementP2;
 use curve25519_dalek::ristretto::RistrettoPoint;
 
-pub trait SwCurveConfig {
+pub trait SwCurveConfig: ark_ec::short_weierstrass::SWCurveConfig {
     fn curve_id() -> u32;
 }
 
@@ -27,7 +27,7 @@ impl Curve for RistrettoPoint {
     }
 }
 
-impl<C: SwCurveConfig + ark_ec::short_weierstrass::SWCurveConfig> Curve for ElementP2<C> {
+impl<C: SwCurveConfig> Curve for ElementP2<C> {
     fn curve_id() -> u32 {
         C::curve_id()
     }

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -2,33 +2,25 @@ use crate::compute::ElementP2;
 use curve25519_dalek::ristretto::RistrettoPoint;
 
 pub trait SwCurveConfig: ark_ec::short_weierstrass::SWCurveConfig {
-    fn curve_id() -> u32;
+    const CURVE_ID: u32;
 }
 
 impl SwCurveConfig for ark_bls12_381::g1::Config {
-    fn curve_id() -> u32 {
-        blitzar_sys::SXT_CURVE_BLS_381
-    }
+    const CURVE_ID: u32 = blitzar_sys::SXT_CURVE_BLS_381;
 }
 
 impl SwCurveConfig for ark_bn254::g1::Config {
-    fn curve_id() -> u32 {
-        blitzar_sys::SXT_CURVE_BN_254
-    }
+    const CURVE_ID: u32 = blitzar_sys::SXT_CURVE_BN_254;
 }
 
-pub trait Curve {
-    fn curve_id() -> u32;
+pub trait CurveId {
+    const CURVE_ID: u32;
 }
 
-impl Curve for RistrettoPoint {
-    fn curve_id() -> u32 {
-        blitzar_sys::SXT_CURVE_RISTRETTO255
-    }
+impl CurveId for RistrettoPoint {
+    const CURVE_ID: u32 = blitzar_sys::SXT_CURVE_RISTRETTO255;
 }
 
-impl<C: SwCurveConfig> Curve for ElementP2<C> {
-    fn curve_id() -> u32 {
-        C::curve_id()
-    }
+impl<C: SwCurveConfig> CurveId for ElementP2<C> {
+    const CURVE_ID: u32 = C::CURVE_ID;
 }

--- a/src/compute/curve.rs
+++ b/src/compute/curve.rs
@@ -1,6 +1,22 @@
 use crate::compute::ElementP2;
 use curve25519_dalek::ristretto::RistrettoPoint;
 
+pub trait SwCurveConfig {
+    fn curve_id() -> u32;
+}
+
+impl SwCurveConfig for ark_bls12_381::g1::Config {
+    fn curve_id() -> u32 {
+        blitzar_sys::SXT_CURVE_BLS_381
+    }
+}
+
+impl SwCurveConfig for ark_bn254::g1::Config {
+    fn curve_id() -> u32 {
+        blitzar_sys::SXT_CURVE_BN_254
+    }
+}
+
 pub trait Curve {
     fn curve_id() -> u32;
 }
@@ -11,14 +27,8 @@ impl Curve for RistrettoPoint {
     }
 }
 
-impl Curve for ElementP2<ark_bls12_381::g1::Config> {
+impl<C: SwCurveConfig + ark_ec::short_weierstrass::SWCurveConfig> Curve for ElementP2<C> {
     fn curve_id() -> u32 {
-        blitzar_sys::SXT_CURVE_BLS_381
-    }
-}
-
-impl Curve for ElementP2<ark_bn254::g1::Config> {
-    fn curve_id() -> u32 {
-        blitzar_sys::SXT_CURVE_BN_254
+        C::curve_id()
     }
 }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -1,8 +1,8 @@
 use super::backend::init_backend;
-use crate::compute::{ElementP2, Curve};
 use crate::compute::curve::SwCurveConfig;
-use std::marker::PhantomData;
+use crate::compute::{Curve, ElementP2};
 use ark_ec::short_weierstrass::Affine;
+use std::marker::PhantomData;
 
 /// Handle to compute multi-scalar multiplications (MSMs) with pre-specified generators
 pub struct MsmHandle<T: Curve> {
@@ -93,16 +93,16 @@ pub trait SwMsmHandle {
     fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]);
 }
 
-impl<C:SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
+impl<C: SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
     type AffineElement = Affine<C>;
 
     fn new(generators: &[Self::AffineElement]) -> Self {
-        let generators : Vec<ElementP2<C>> = generators.iter().map(|e| e.into()).collect();
+        let generators: Vec<ElementP2<C>> = generators.iter().map(|e| e.into()).collect();
         MsmHandle::new(&generators)
     }
 
     fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]) {
-        let mut res_p : Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
+        let mut res_p: Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
         self.msm(&mut res_p, element_num_bytes, scalars);
         for (resi, resi_p) in res.iter_mut().zip(res_p) {
             *resi = resi_p.into();

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -84,13 +84,18 @@ impl<T: Curve> Drop for MsmHandle<T> {
 pub trait SwMsmHandle {
     type Element;
 
-    // fn new(generators: &[Self::Element]) -> Self;
+    fn new(generators: &[Self::Element]) -> Self;
 
     fn msm(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]);
 }
 
 impl<C:SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
     type Element = Affine<C>;
+
+    fn new(generators: &[Self::Element]) -> Self {
+        let generators : Vec<ElementP2<C>> = generators.iter().map(|e| e.into()).collect();
+        MsmHandle::new(&generators)
+    }
 
     fn msm(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]) {
         let mut res_p : Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -1,4 +1,3 @@
-// use super::backend::init_backend;
 use super::backend::init_backend;
 use crate::compute::Curve;
 use std::marker::PhantomData;

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -81,27 +81,27 @@ impl<T: Curve> Drop for MsmHandle<T> {
     }
 }
 
-/// TODO(rnburn)
+/// Extend MsmHandle to work with affine coordinates for short Weierstrass curve elements
 pub trait SwMsmHandle {
-    /// TODO(rnburn)
-    type Element;
+    /// Type of an Affine curve element
+    type AffineElement;
 
-    /// todo
-    fn new(generators: &[Self::Element]) -> Self;
+    /// Create a handle from affine generators
+    fn new(generators: &[Self::AffineElement]) -> Self;
 
-    /// todo
-    fn msmAffine(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]);
+    /// Compute a MSM with the result given as affine elements
+    fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]);
 }
 
 impl<C:SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
-    type Element = Affine<C>;
+    type AffineElement = Affine<C>;
 
-    fn new(generators: &[Self::Element]) -> Self {
+    fn new(generators: &[Self::AffineElement]) -> Self {
         let generators : Vec<ElementP2<C>> = generators.iter().map(|e| e.into()).collect();
         MsmHandle::new(&generators)
     }
 
-    fn msmAffine(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]) {
+    fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]) {
         let mut res_p : Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
         self.msm(&mut res_p, element_num_bytes, scalars);
         for (resi, resi_p) in res.iter_mut().zip(res_p) {

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -87,7 +87,7 @@ pub trait SwMsmHandle {
     type AffineElement;
 
     /// Create a handle from affine generators
-    fn new(generators: &[Self::AffineElement]) -> Self;
+    fn new_with_affine(generators: &[Self::AffineElement]) -> Self;
 
     /// Compute a MSM with the result given as affine elements
     fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]);
@@ -96,7 +96,7 @@ pub trait SwMsmHandle {
 impl<C: SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
     type AffineElement = Affine<C>;
 
-    fn new(generators: &[Self::AffineElement]) -> Self {
+    fn new_with_affine(generators: &[Self::AffineElement]) -> Self {
         let generators: Vec<ElementP2<C>> = generators.iter().map(|e| e.into()).collect();
         MsmHandle::new(&generators)
     }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -2,6 +2,7 @@ use super::backend::init_backend;
 use crate::compute::curve::SwCurveConfig;
 use crate::compute::{Curve, ElementP2};
 use ark_ec::short_weierstrass::Affine;
+use rayon::prelude::*;
 use std::marker::PhantomData;
 
 /// Handle to compute multi-scalar multiplications (MSMs) with pre-specified generators
@@ -104,8 +105,8 @@ impl<C: SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
     fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]) {
         let mut res_p: Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
         self.msm(&mut res_p, element_num_bytes, scalars);
-        for (resi, resi_p) in res.iter_mut().zip(res_p) {
+        res.par_iter_mut().zip(res_p).for_each(|(resi, resi_p)| {
             *resi = resi_p.into();
-        }
+        });
     }
 }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -81,12 +81,16 @@ impl<T: Curve> Drop for MsmHandle<T> {
     }
 }
 
+/// TODO(rnburn)
 pub trait SwMsmHandle {
+    /// TODO(rnburn)
     type Element;
 
+    /// todo
     fn new(generators: &[Self::Element]) -> Self;
 
-    fn msm(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]);
+    /// todo
+    fn msmAffine(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]);
 }
 
 impl<C:SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
@@ -97,7 +101,7 @@ impl<C:SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
         MsmHandle::new(&generators)
     }
 
-    fn msm(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]) {
+    fn msmAffine(&self, res: &mut [Self::Element], element_num_bytes: u32, scalars: &[u8]) {
         let mut res_p : Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
         self.msm(&mut res_p, element_num_bytes, scalars);
         for (resi, resi_p) in res.iter_mut().zip(res_p) {

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -1,17 +1,17 @@
 use super::backend::init_backend;
 use crate::compute::curve::SwCurveConfig;
-use crate::compute::{Curve, ElementP2};
+use crate::compute::{CurveId, ElementP2};
 use ark_ec::short_weierstrass::Affine;
 use rayon::prelude::*;
 use std::marker::PhantomData;
 
 /// Handle to compute multi-scalar multiplications (MSMs) with pre-specified generators
-pub struct MsmHandle<T: Curve> {
+pub struct MsmHandle<T: CurveId> {
     handle: *mut blitzar_sys::sxt_multiexp_handle,
     phantom: PhantomData<T>,
 }
 
-impl<T: Curve> MsmHandle<T> {
+impl<T: CurveId> MsmHandle<T> {
     /// New handle from the specified generators.
     ///
     /// Note: any MSMs computed with the handle must have length less than or equal
@@ -21,7 +21,7 @@ impl<T: Curve> MsmHandle<T> {
 
         unsafe {
             let handle = blitzar_sys::sxt_multiexp_handle_new(
-                T::curve_id(),
+                T::CURVE_ID,
                 generators.as_ptr() as *const std::ffi::c_void,
                 generators.len() as u32,
             );
@@ -74,7 +74,7 @@ impl<T: Curve> MsmHandle<T> {
     }
 }
 
-impl<T: Curve> Drop for MsmHandle<T> {
+impl<T: CurveId> Drop for MsmHandle<T> {
     fn drop(&mut self) {
         unsafe {
             blitzar_sys::sxt_multiexp_handle_free(self.handle);

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -107,7 +107,8 @@ fn for_short_weierstrass_curvs_we_can_compute_msms_with_affine_elements() {
     let g = generators[0];
 
     // create handle
-    let handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>> = SwMsmHandle::new(&generators);
+    let handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>> =
+        MsmHandle::new_with_affine(&generators);
 
     // 2 * g
     let scalars: Vec<u8> = vec![2];

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -112,6 +112,6 @@ fn for_short_weierstrass_curvs_we_can_compute_msms_with_affine_elements() {
 
     // 2 * g
     let scalars: Vec<u8> = vec![2];
-    handle.msmAffine(&mut res, 1, &scalars);
+    handle.affine_msm(&mut res, 1, &scalars);
     assert_eq!(res[0], g + g);
 }

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -102,13 +102,12 @@ fn for_short_weierstrass_curvs_we_can_compute_msms_with_affine_elements() {
     let mut res = vec![G1Affine::default(); 1];
 
     // randomly obtain the generator points
-    let generators : Vec<G1Affine> =
-        (0..1).map(|_| G1Affine::rand(&mut rng)).collect();
+    let generators: Vec<G1Affine> = (0..1).map(|_| G1Affine::rand(&mut rng)).collect();
 
     let g = generators[0];
 
     // create handle
-    let handle : MsmHandle<ElementP2<ark_bls12_381::g1::Config>> = SwMsmHandle::new(&generators);
+    let handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>> = SwMsmHandle::new(&generators);
 
     // 2 * g
     let scalars: Vec<u8> = vec![2];

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -94,3 +94,24 @@ fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let r: G1Affine = res[0].clone().into();
     assert_eq!(r, g + g);
 }
+
+#[test]
+fn for_short_weierstrass_curvs_we_can_compute_msms_with_affine_elements() {
+    let mut rng = ark_std::test_rng();
+
+    let mut res = vec![G1Affine::default(); 1];
+
+    // randomly obtain the generator points
+    let generators : Vec<G1Affine> =
+        (0..1).map(|_| G1Affine::rand(&mut rng)).collect();
+
+    let g = generators[0];
+
+    // create handle
+    let handle : MsmHandle<ElementP2<ark_bls12_381::g1::Config>> = SwMsmHandle::new(&generators);
+
+    // 2 * g
+    let scalars: Vec<u8> = vec![2];
+    handle.msmAffine(&mut res, 1, &scalars);
+    assert_eq!(res[0], g + g);
+}

--- a/src/compute/fixed_sw_msm.rs
+++ b/src/compute/fixed_sw_msm.rs
@@ -1,7 +1,0 @@
-use crate::compute::Curve;
-use std::marker::PhantomData;
-
-pub struct SwMsmHandle<T: Curve> {
-    phantom: PhantomData<T>,
-}
-

--- a/src/compute/fixed_sw_msm.rs
+++ b/src/compute/fixed_sw_msm.rs
@@ -1,0 +1,7 @@
+use crate::compute::Curve;
+use std::marker::PhantomData;
+
+pub struct SwMsmHandle<T: Curve> {
+    phantom: PhantomData<T>,
+}
+

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -36,7 +36,7 @@ pub use element_p2::ElementP2;
 mod element_p2_test;
 
 mod fixed_msm;
-pub use fixed_msm::MsmHandle;
+pub use fixed_msm::{MsmHandle, SwMsmHandle};
 #[cfg(test)]
 mod fixed_msm_tests;
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -40,11 +40,6 @@ pub use fixed_msm::MsmHandle;
 #[cfg(test)]
 mod fixed_msm_tests;
 
-mod fixed_sw_msm;
-// pub use fixed_msm::MsmHandle;
-// #[cfg(test)]
-// mod fixed_msm_tests;
-
 mod generators;
 pub use generators::{get_curve25519_generators, get_one_curve25519_commit};
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -18,7 +18,7 @@ mod backend;
 pub use backend::{init_backend, init_backend_with_config, BackendConfig};
 
 mod curve;
-use curve::Curve;
+use curve::CurveId;
 
 mod commitments;
 pub use commitments::{

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -40,6 +40,11 @@ pub use fixed_msm::MsmHandle;
 #[cfg(test)]
 mod fixed_msm_tests;
 
+mod fixed_sw_msm;
+// pub use fixed_msm::MsmHandle;
+// #[cfg(test)]
+// mod fixed_msm_tests;
+
 mod generators;
 pub use generators::{get_curve25519_generators, get_one_curve25519_commit};
 


### PR DESCRIPTION
# Rationale for this change

Make it more easy to work with elements in affine form using MsmHandle.

# What changes are included in this PR?

Add the trait SwMsmHandle to extent MsmHandle with methods for affine points.

# Are these changes tested?

Yes
