### PR TITLE
fix: upgrade `blitzar-sys` to 1.64.1 (PROOF-882)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
 rayon = { version = "1.5" }
-blitzar-sys = { version = "1.56.0" }
+blitzar-sys = { version = "1.64.1" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }


### PR DESCRIPTION
# Rationale for this change
In order to incorporate the fix in [this PR](https://github.com/spaceandtimelabs/blitzar/pull/144) into [proof-of-sql](https://github.com/spaceandtimelabs/sxt-proof-of-sql) we need to upgrade `blitzar-sys` dependency here.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Bump `blitzar-sys` minimal version requirement to 1.64.1
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
