### PR TITLE
feat: support multi-exponentiations in packed format (PROOF-877)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
 rayon = { version = "1.5" }
-blitzar-sys = { version = "1.64.1" }
+blitzar-sys = { version = "1.70.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -106,7 +106,7 @@ impl<T: CurveId> MsmHandle<T> {
     pub fn packed_msm(&self, res: &mut [T], output_bit_table: &[u32], scalars: &[u8]) {
         let num_outputs = res.len() as u32;
         let bit_sum : u32 = output_bit_table.iter().sum();
-        let num_output_bytes = ((bit_sum + 7) / 8) * 8 as u32;
+        let num_output_bytes = ((bit_sum + 7) / 8) as u32;
         assert!(scalars.len() as u32 % num_output_bytes == 0);
         let n = scalars.len() as u32 / num_output_bytes;
         unsafe {

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -98,7 +98,7 @@ impl<T: CurveId> MsmHandle<T> {
     pub fn packed_msm(&self, res: &mut [T], output_bit_table: &[u32], scalars: &[u8]) {
         let num_outputs = res.len() as u32;
         let bit_sum: u32 = output_bit_table.iter().sum();
-        let num_output_bytes = ((bit_sum + 7) / 8) as u32;
+        let num_output_bytes = (bit_sum + 7) / 8;
         assert!(scalars.len() as u32 % num_output_bytes == 0);
         let n = scalars.len() as u32 / num_output_bytes;
         unsafe {

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -78,31 +78,23 @@ impl<T: CurveId> MsmHandle<T> {
         }
     }
 
-    /// Compute an MSM using pre-specified generators.
+    /// Compute an MSM in packed format using pre-specified generators.
     ///
-    /// Suppose g_1, ..., g_n are pre-specified generators and
+    /// On completion `res` contains an array of size `num_outputs` for the multiexponentiation
+    /// of the given `scalars` array.
     ///
-    ///    s_11, s_12, ..., s_1n
-    ///    s_21, s_22, ..., s_2n
-    ///    .
-    ///    .   .
-    ///    .       .
-    ///    s_m1, sm2, ..., s_mn
+    /// An entry output_bit_table[output_index] specifies the number of scalar bits used for
+    /// output_index.
     ///
-    /// is an array of scalars of element_num_bytes each.
+    /// Put
+    ///     bit_sum = sum_{output_index} output_bit_table[output_index]
+    /// and let num_bytes denote the smallest integer greater than or equal to bit_sum that is a
+    /// multiple of 8.
     ///
-    /// If msm is called with the slice of scalars of size element_num_bytes * m * n
-    /// defined by
     ///
-    ///    scalars = [s_11, s_21, ..., s_m1, s_12, s_22, ..., s_m2, ..., s_mn ]
-    ///
-    /// then res will contain the MSM result
-    ///
-    ///    res[0] = s_11 * g_1 + s_12 * g_2 + ... + s_1n * g_n
-    ///       .
-    ///       .
-    ///       .
-    ///    res[m-1] = s_m1 * g_1 + s_12 * g_2 + ... + s_mn * g_n
+    /// `scalars` specifies a contiguous multi-dimension `num_bytes` by `n` array laid out in
+    /// a packed column-major order as specified by output_bit_table. A given row determines the scalar
+    /// exponents for generator g_i with the output scalars packed contiguously and padded with zeros.
     pub fn packed_msm(&self, res: &mut [T], output_bit_table: &[u32], scalars: &[u8]) {
         let num_outputs = res.len() as u32;
         let bit_sum : u32 = output_bit_table.iter().sum();

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -97,7 +97,7 @@ impl<T: CurveId> MsmHandle<T> {
     /// exponents for generator g_i with the output scalars packed contiguously and padded with zeros.
     pub fn packed_msm(&self, res: &mut [T], output_bit_table: &[u32], scalars: &[u8]) {
         let num_outputs = res.len() as u32;
-        let bit_sum : u32 = output_bit_table.iter().sum();
+        let bit_sum: u32 = output_bit_table.iter().sum();
         let num_output_bytes = ((bit_sum + 7) / 8) as u32;
         assert!(scalars.len() as u32 % num_output_bytes == 0);
         let n = scalars.len() as u32 / num_output_bytes;
@@ -134,7 +134,12 @@ pub trait SwMsmHandle {
     fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]);
 
     /// Compute a packed MSM with the result given as affine elements
-    fn affine_packed_msm(&self, res: &mut [Self::AffineElement], output_bit_table: &[u32], scalars: &[u8]);
+    fn affine_packed_msm(
+        &self,
+        res: &mut [Self::AffineElement],
+        output_bit_table: &[u32],
+        scalars: &[u8],
+    );
 }
 
 impl<C: SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
@@ -153,7 +158,12 @@ impl<C: SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
         });
     }
 
-    fn affine_packed_msm(&self, res: &mut [Self::AffineElement], output_bit_table: &[u32], scalars: &[u8]) {
+    fn affine_packed_msm(
+        &self,
+        res: &mut [Self::AffineElement],
+        output_bit_table: &[u32],
+        scalars: &[u8],
+    ) {
         let mut res_p: Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
         self.packed_msm(&mut res_p, output_bit_table, scalars);
         res.par_iter_mut().zip(res_p).for_each(|(resi, resi_p)| {

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -140,6 +140,9 @@ pub trait SwMsmHandle {
 
     /// Compute a MSM with the result given as affine elements
     fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]);
+
+    /// Compute a packed MSM with the result given as affine elements
+    fn affine_packed_msm(&self, res: &mut [Self::AffineElement], output_bit_table: &[u32], scalars: &[u8]);
 }
 
 impl<C: SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
@@ -153,6 +156,14 @@ impl<C: SwCurveConfig + Clone> SwMsmHandle for MsmHandle<ElementP2<C>> {
     fn affine_msm(&self, res: &mut [Self::AffineElement], element_num_bytes: u32, scalars: &[u8]) {
         let mut res_p: Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
         self.msm(&mut res_p, element_num_bytes, scalars);
+        res.par_iter_mut().zip(res_p).for_each(|(resi, resi_p)| {
+            *resi = resi_p.into();
+        });
+    }
+
+    fn affine_packed_msm(&self, res: &mut [Self::AffineElement], output_bit_table: &[u32], scalars: &[u8]) {
+        let mut res_p: Vec<ElementP2<C>> = vec![ElementP2::<C>::default(); res.len()];
+        self.packed_msm(&mut res_p, output_bit_table, scalars);
         res.par_iter_mut().zip(res_p).for_each(|(resi, resi_p)| {
             *resi = resi_p.into();
         });

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -74,6 +74,28 @@ fn we_can_compute_msms_using_multiple_outputs() {
 }
 
 #[test]
+fn we_can_compute_packed_msms() {
+    let mut rng = OsRng;
+
+    let mut res = vec![RistrettoPoint::default(); 2];
+
+    // randomly obtain the generator points
+    let generators: Vec<RistrettoPoint> =
+        (0..2).map(|_| RistrettoPoint::random(&mut rng)).collect();
+
+    // create handle
+    let handle = MsmHandle::new(&generators);
+
+    // g[0] + 3 * g[1]
+    // g[0]
+    let output_bit_table: Vec<u32> = vec![3, 1];
+    let scalars: Vec<u8> = vec![0b1001, 0b0011];
+    handle.packed_msm(&mut res, &output_bit_table, &scalars);
+    assert_eq!(res[0], generators[0] + generators[1] + generators[1] + generators[1]);
+    assert_eq!(res[1], generators[0]);
+}
+
+#[test]
 fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let mut rng = ark_std::test_rng();
 

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -136,4 +136,8 @@ fn for_short_weierstrass_curvs_we_can_compute_msms_with_affine_elements() {
     let scalars: Vec<u8> = vec![2];
     handle.affine_msm(&mut res, 1, &scalars);
     assert_eq!(res[0], g + g);
+
+    let output_bit_table: Vec<u32> = vec![2];
+    handle.affine_packed_msm(&mut res, &output_bit_table, &scalars);
+    assert_eq!(res[0], g + g);
 }

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -91,7 +91,10 @@ fn we_can_compute_packed_msms() {
     let output_bit_table: Vec<u32> = vec![3, 1];
     let scalars: Vec<u8> = vec![0b1001, 0b0011];
     handle.packed_msm(&mut res, &output_bit_table, &scalars);
-    assert_eq!(res[0], generators[0] + generators[1] + generators[1] + generators[1]);
+    assert_eq!(
+        res[0],
+        generators[0] + generators[1] + generators[1] + generators[1]
+    );
     assert_eq!(res[1], generators[0]);
 }
 


### PR DESCRIPTION
# Rationale for this change

Improve the performance of multi-exponentiations with multiple outputs of varying bit lengths by adding a packed interface.

# What changes are included in this PR?

* Adds a new packed_msm method to MsmHandle.

# Are these changes tested?

Yes
