### PR TITLE
feat: add interface for variable length MSMs (PROOF-896)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
 rayon = { version = "1.5" }
-blitzar-sys = { version = "1.70.0" }
+blitzar-sys = { version = "1.78.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -112,6 +112,29 @@ impl<T: CurveId> MsmHandle<T> {
             );
         }
     }
+
+    /// TODO doc me
+    pub fn vlen_msm(
+        &self,
+        res: &mut [T],
+        output_bit_table: &[u32],
+        output_lengths: &[u32],
+        scalars: &[u8],
+    ) {
+        let num_outputs = res.len() as u32;
+        assert_eq!(output_bit_table.len(), num_outputs as usize);
+        assert_eq!(output_lengths.len(), num_outputs as usize);
+        unsafe {
+            blitzar_sys::sxt_fixed_vlen_multiexponentiation(
+                res.as_ptr() as *mut std::ffi::c_void,
+                self.handle,
+                output_bit_table.as_ptr(),
+                output_lengths.as_ptr(),
+                num_outputs,
+                scalars.as_ptr(),
+            );
+        }
+    }
 }
 
 impl<T: CurveId> Drop for MsmHandle<T> {

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -166,4 +166,8 @@ fn for_short_weierstrass_curvs_we_can_compute_msms_with_affine_elements() {
     let output_bit_table: Vec<u32> = vec![2];
     handle.affine_packed_msm(&mut res, &output_bit_table, &scalars);
     assert_eq!(res[0], g + g);
+
+    let output_lengths: Vec<u32> = vec![1];
+    handle.affine_vlen_msm(&mut res, &output_bit_table, &output_lengths, &scalars);
+    assert_eq!(res[0], g + g);
 }

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -99,6 +99,29 @@ fn we_can_compute_packed_msms() {
 }
 
 #[test]
+fn we_can_compute_variable_length_msms() {
+    let mut rng = OsRng;
+
+    let mut res = vec![RistrettoPoint::default(); 2];
+
+    // randomly obtain the generator points
+    let generators: Vec<RistrettoPoint> =
+        (0..2).map(|_| RistrettoPoint::random(&mut rng)).collect();
+
+    // create handle
+    let handle = MsmHandle::new(&generators);
+
+    // g[0]
+    // g[0] + g[1]
+    let output_bit_table: Vec<u32> = vec![3, 1];
+    let output_lengths: Vec<u32> = vec![1, 2];
+    let scalars: Vec<u8> = vec![0b1001, 0b1011];
+    handle.vlen_msm(&mut res, &output_bit_table, &output_lengths, &scalars);
+    assert_eq!(res[0], generators[0]);
+    assert_eq!(res[1], generators[0] + generators[1]);
+}
+
+#[test]
 fn we_can_compute_msms_using_a_single_generator_bls12_381() {
     let mut rng = ark_std::test_rng();
 


### PR DESCRIPTION
# Rationale for this change

Add a new interface to improve the performance of multi-exponentiations with outputs of varying length.

# What changes are included in this PR?

Adds new vlen_msm and affine_vlen_msm methods.

# Are these changes tested?

Yes
