### PR TITLE
docs: update Rust and CUDA version in docs (PROOF-902)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@
   </a>
 
   <a href="https://www.rust-lang.org/">
-    <img alt="Rust" src="https://img.shields.io/badge/rust-1.76.0-blue">
+    <img alt="Rust" src="https://img.shields.io/badge/rust-1.80-blue">
     </a>
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.3.1-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
     </a>
   </a>
 
@@ -117,9 +117,9 @@ To get a local copy up and running, consider the following steps.
 <details open>
 <summary>GPU backend prerequisites:</summary>
 
-* [Rust 1.76.0](https://www.rust-lang.org/tools/install)
+* [Rust 1.80](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* Nvidia Toolkit Driver Version: >= 545.23.08 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* Nvidia Toolkit Driver Version >= 550 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 
@@ -128,7 +128,7 @@ To get a local copy up and running, consider the following steps.
 
 You'll need the following requirements to run the environment:
 
-* [Rust 1.76.0](https://www.rust-lang.org/tools/install)
+* [Rust 1.80](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To get a local copy up and running, consider the following steps.
 
 * [Rust 1.80](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* Nvidia Toolkit Driver Version >= 550 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* Nvidia Toolkit Driver Version >= 560.28.03 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,10 @@
 //!     <img alt="crates.io version" src="https://img.shields.io/crates/v/blitzar.svg">
 //!   </a>
 //!   <a href="https://www.rust-lang.org/">
-//!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.76.0-blue">
+//!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.80-blue">
 //!  </a>
 //!  <a href="https://developer.nvidia.com/cuda-downloads">
-//!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.3.1-green?style=flat&logo=nvidia">
+//!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
 //!  </a>
 //!   <a href="https://github.com/spaceandtimelabs/blitzar-rs">
 //!     <img alt="Build states" src="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml/badge.svg">


### PR DESCRIPTION
# Rationale for this change
The docs should match recent version bumps. Rust 1.80 was updated in the blitzar-rs repo in https://github.com/spaceandtimelabs/blitzar-rs/pull/36 and CUDA 12.6 was updated in Blitzar in https://github.com/spaceandtimelabs/blitzar/pull/172.

# What changes are included in this PR?
- Bump Rust to version `1.80` in the docs
- Bump CUDA to version `12.6` in the docs

# Are these changes tested?
Yes