### PR TITLE
ci: install nvidia driver in workflow (PROOF-911)

### DIFF
--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -40,19 +40,31 @@ jobs:
     name: Test the GPU backend
     runs-on: nvidia-nc4as-t4
     steps:
-      - name: Checkout Code
+      - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install NVIDIA driver
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install stable toolchain
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+
+      - name: Install Dependencies
         run: |
           export DEBIAN_FRONTEND=non-interactive
           sudo apt-get update
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:graphics-drivers/ppa
           sudo apt-get update
-          sudo apt-get install -y nvidia-open-560
+          sudo apt-get install -y nvidia-driver-560
 
-      - name: Run Docker with GPU
-        run: |
-          docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "nvidia-smi"
-          docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"
+      - name: Run GPU test
+        run: cargo test --features gpu"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -71,4 +71,4 @@ jobs:
           sudo apt-get install -y nvidia-open-560
 
       - name: Run GPU test
-        run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"
+        run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged nvidia/cuda:12.6.1-runtime-ubuntu24.04 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -12,29 +12,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # format-code:
-  #   name: Check Code
-  #   runs-on: nvidia-nc4as-t4
-  #   steps:
-  #     - name: Checkout Code Format
-  #       uses: actions/checkout@v3
-  #     - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; rustup component add rustfmt; cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check"
+  format-code:
+    name: Check Code
+    runs-on: nvidia-nc4as-t4
+    steps:
+      - name: Checkout Code Format
+        uses: actions/checkout@v3
 
-  # clippy-code:
-  #   name: Clippy Code
-  #   runs-on: nvidia-nc4as-t4
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v3
-  #     - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; rustup component add clippy; cargo clippy --all-targets --all-features -- -D warnings"
+      - name: Install stable toolchain
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
 
-  # test-cpu:
-  #   name: Test the CPU backend
-  #   runs-on: nvidia-nc4as-t4
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v3
-  #     - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features cpu"
+      - name: Install Dependencies
+        run: |
+          source ~/.cargo/env
+          rustup component add rustfmt
+
+      - name: Run Code Format
+        run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
+
+  clippy-code:
+    name: Clippy Code
+    runs-on: nvidia-nc4as-t4
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+
+      - name: Install Dependencies
+        run: |
+          source ~/.cargo/env
+          rustup component add clippy
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test-cpu:
+    name: Test the CPU backend
+    runs-on: nvidia-nc4as-t4
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+
+      - name: Run CPU test
+        run: |
+          source ~/.cargo/env
+          cargo test --features cpu
 
   test-gpu:
     name: Test the GPU backend

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:graphics-drivers/ppa
           sudo apt-get update
-          sudo apt-get install -y nvidia-open-560
+          sudo apt-get install -y nvidia-open-560 nvidia-container-runtime
 
       - name: Run GPU test
         run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged nvidia/cuda:12.6.1-runtime-ubuntu24.04 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -53,6 +53,10 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-
 
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -71,4 +71,4 @@ jobs:
           sudo apt-get install -y nvidia-open-560
 
       - name: Run GPU test
-        run: cargo test --features gpu
+        run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:graphics-drivers/ppa
           sudo apt-get update
-          sudo apt-get install -y nvidia-driver-560
+          sudo apt-get install -y nvidia-open-560
 
       - name: Run Docker with GPU
         run: |

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -11,32 +11,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CARGO_TERM_COLOR: always  
-
 jobs:
   format-code:
     name: Check Code
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code Format
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}        
-
       - name: Install stable toolchain
-        run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
-          rustup component add rustfmt
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+
+      - name: Install Dependencies
+        run: rustup component add rustfmt
 
       - name: Run Code Format
         run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
@@ -44,20 +34,12 @@ jobs:
   clippy-code:
     name: Clippy Code
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}        
 
       - name: Install stable toolchain
         run: |
@@ -70,23 +52,15 @@ jobs:
   test-cpu:
     name: Test the CPU backend
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-test-cpu-${{ hashFiles('**/Cargo.toml') }}
-
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
       - name: Run CPU test
         run: cargo test --features cpu
@@ -94,23 +68,15 @@ jobs:
   test-gpu:
     name: Test the GPU backend
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-test-gpu-${{ hashFiles('**/Cargo.toml') }}        
-
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -28,7 +28,9 @@ jobs:
           rustup component add rustfmt
 
       - name: Run Code Format
-        run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
+        run: |
+          source ~/.cargo/env
+          cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
 
   clippy-code:
     name: Clippy Code
@@ -44,8 +46,11 @@ jobs:
         run: |
           source ~/.cargo/env
           rustup component add clippy
+
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: |
+          source ~/.cargo/env
+          cargo clippy --all-targets --all-features -- -D warnings
 
   test-cpu:
     name: Test the CPU backend

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install stable toolchain
         run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
           rustup component add clippy
 
       - name: Run Clippy

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -12,29 +12,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  format-code:
-    name: Check Code
-    runs-on: nvidia-nc4as-t4
-    steps:
-      - name: Checkout Code Format
-        uses: actions/checkout@v3
-      - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; rustup component add rustfmt; cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check"
+  # format-code:
+  #   name: Check Code
+  #   runs-on: nvidia-nc4as-t4
+  #   steps:
+  #     - name: Checkout Code Format
+  #       uses: actions/checkout@v3
+  #     - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; rustup component add rustfmt; cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check"
 
-  clippy-code:
-    name: Clippy Code
-    runs-on: nvidia-nc4as-t4
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; rustup component add clippy; cargo clippy --all-targets --all-features -- -D warnings"
+  # clippy-code:
+  #   name: Clippy Code
+  #   runs-on: nvidia-nc4as-t4
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v3
+  #     - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; rustup component add clippy; cargo clippy --all-targets --all-features -- -D warnings"
 
-  test-cpu:
-    name: Test the CPU backend
-    runs-on: nvidia-nc4as-t4
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features cpu"
+  # test-cpu:
+  #   name: Test the CPU backend
+  #   runs-on: nvidia-nc4as-t4
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v3
+  #     - run: docker run --rm -v "$PWD":/src:ro -w /src --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features cpu"
 
   test-gpu:
     name: Test the GPU backend
@@ -64,7 +64,7 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:graphics-drivers/ppa
           sudo apt-get update
-          sudo apt-get install -y nvidia-driver-560
+          sudo apt-get install -y nvidia-open-560
 
       - name: Run GPU test
         run: cargo test --features gpu"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -67,4 +67,4 @@ jobs:
           sudo apt-get install -y nvidia-open-560
 
       - name: Run GPU test
-        run: cargo test --features gpu"
+        run: cargo test --features gpu

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -15,67 +15,69 @@ jobs:
   format-code:
     name: Check Code
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code Format
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
       - name: Install Dependencies
-        run: |
-          source ~/.cargo/env
-          rustup component add rustfmt
+        run: rustup component add rustfmt
 
       - name: Run Code Format
-        run: |
-          source ~/.cargo/env
-          cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
+        run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
 
   clippy-code:
     name: Clippy Code
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
       - name: Install Dependencies
-        run: |
-          source ~/.cargo/env
-          rustup component add clippy
+        run: rustup component add clippy
 
       - name: Run Clippy
-        run: |
-          source ~/.cargo/env
-          cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   test-cpu:
     name: Test the CPU backend
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
       - name: Run CPU test
-        run: |
-          source ~/.cargo/env
-          cargo test --features cpu
+        run: cargo test --features cpu
 
   test-gpu:
     name: Test the GPU backend
     runs-on: nvidia-nc4as-t4
+    env:
+      CARGO_HOME: ${{ github.workspace }}/.cargo
+      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
       - name: Install Dependencies
         run: |
@@ -87,6 +89,4 @@ jobs:
           sudo apt-get install -y nvidia-open-560
 
       - name: Run GPU test
-        run: |
-          source ~/.cargo/env
-          cargo test --features gpu
+        run: cargo test --features gpu

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -11,22 +11,32 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always  
+
 jobs:
   format-code:
     name: Check Code
     runs-on: nvidia-nc4as-t4
-    env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code Format
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}        
 
-      - name: Install Dependencies
-        run: rustup component add rustfmt
+      - name: Install stable toolchain
+        run: |
+          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+          rustup component add rustfmt
 
       - name: Run Code Format
         run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
@@ -34,18 +44,25 @@ jobs:
   clippy-code:
     name: Clippy Code
     runs-on: nvidia-nc4as-t4
-    env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}        
 
-      - name: Install Dependencies
-        run: rustup component add clippy
+      - name: Install stable toolchain
+        run: |
+          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+          rustup component add clippy
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -53,15 +70,23 @@ jobs:
   test-cpu:
     name: Test the CPU backend
     runs-on: nvidia-nc4as-t4
-    env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-cpu-${{ hashFiles('**/Cargo.toml') }}
+
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
 
       - name: Run CPU test
         run: cargo test --features cpu
@@ -69,15 +94,23 @@ jobs:
   test-gpu:
     name: Test the GPU backend
     runs-on: nvidia-nc4as-t4
-    env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-gpu-${{ hashFiles('**/Cargo.toml') }}        
+
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -43,20 +43,20 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-
-            ${{ runner.os }}-cargo-
-            ${{ runner.os }}-
+      # - name: Cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       ~/.cargo/bin/
+      #       ~/.cargo/registry/index/
+      #       ~/.cargo/registry/cache/
+      #       ~/.cargo/git/db/
+      #       target/
+      #     key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-cargo-test-
+      #       ${{ runner.os }}-cargo-
+      #       ${{ runner.os }}-
 
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
@@ -71,4 +71,4 @@ jobs:
           sudo apt-get install -y nvidia-open-560 nvidia-container-runtime
 
       - name: Run GPU test
-        run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged nvidia/cuda:12.6.1-runtime-ubuntu24.04 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"
+        run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --runtime=nvidia nvidia/cuda:12.6.1-runtime-ubuntu24.04 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -42,5 +42,17 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "nvidia-smi"
-      - run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"
+
+      - name: Install NVIDIA driver
+        run: |
+          export DEBIAN_FRONTEND=non-interactive
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository ppa:graphics-drivers/ppa
+          sudo apt-get update
+          sudo apt-get install -y nvidia-driver-560
+
+      - name: Run Docker with GPU
+        run: |
+          docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "nvidia-smi"
+          docker run --rm -v "$PWD":/src:ro -w /src --gpus all --privileged rust:1.80 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -43,21 +43,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      # - name: Cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-test-
-      #       ${{ runner.os }}-cargo-
-      #       ${{ runner.os }}-
-
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
 
@@ -68,7 +53,9 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:graphics-drivers/ppa
           sudo apt-get update
-          sudo apt-get install -y nvidia-open-560 nvidia-container-runtime
+          sudo apt-get install -y nvidia-open-560
 
       - name: Run GPU test
-        run: docker run --rm -v "$PWD":/src:ro -w /src --gpus all --runtime=nvidia nvidia/cuda:12.6.1-runtime-ubuntu24.04 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; cargo test --features gpu"
+        run: |
+          source ~/.cargo/env
+          cargo test --features gpu


### PR DESCRIPTION
# Rationale for this change
Blitzar now checks to the version of the Nvidia driver and will panic if the version is under `nvidia-driver-560`. This panic causes the CI to fail. This PR installs the Nvidia driver before running tests with the GPU.

# What changes are included in this PR?
- The CI workflow removes docker in favor of installing Rust. This aligns the workflow with the `sxt-proof-of-sql` repo and will keep Rust up to date.
- The Nvidia 560 driver is installed before testing the GPU.

# Are these changes tested?
Yes, via CI.