### PR TITLE
docs: update NVIDIA driver version (PROOF-917)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6.1-green?style=flat&logo=nvidia">
     </a>
   </a>
 
@@ -119,7 +119,7 @@ To get a local copy up and running, consider the following steps.
 
 * [Rust 1.80](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* Nvidia Toolkit Driver Version >= 560.28.03 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* NVIDIA driver version >= 560.35.03 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.80-blue">
 //!  </a>
 //!  <a href="https://developer.nvidia.com/cuda-downloads">
-//!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
+//!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6.1-green?style=flat&logo=nvidia">
 //!  </a>
 //!   <a href="https://github.com/spaceandtimelabs/blitzar-rs">
 //!     <img alt="Build states" src="https://github.com/spaceandtimelabs/blitzar-rs/actions/workflows/release.yml/badge.svg">


### PR DESCRIPTION
# Rationale for this change
This PR updates the NVIDIA driver version in the docs to reflect the upgrade to CUDA toolkit 12.6.1 in `blitzar`: https://github.com/spaceandtimelabs/blitzar/pull/183

# What changes are included in this PR?
- The required NVIDIA driver version is updated to `560.35.03`

# Are these changes tested?
Yes
