### PR TITLE
build: update rust version (PROOF-918)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #
     container:
-      image: rust:1.80
+      image: rust:1.81
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   </a>
 
   <a href="https://www.rust-lang.org/">
-    <img alt="Rust" src="https://img.shields.io/badge/rust-1.80-blue">
+    <img alt="Rust" src="https://img.shields.io/badge/rust-1.81-blue">
     </a>
   </a>
 
@@ -117,7 +117,7 @@ To get a local copy up and running, consider the following steps.
 <details open>
 <summary>GPU backend prerequisites:</summary>
 
-* [Rust 1.80](https://www.rust-lang.org/tools/install)
+* [Rust 1.81](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
 * Nvidia Toolkit Driver Version >= 560.28.03 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
@@ -128,7 +128,7 @@ To get a local copy up and running, consider the following steps.
 
 You'll need the following requirements to run the environment:
 
-* [Rust 1.80](https://www.rust-lang.org/tools/install)
+* [Rust 1.81](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
 
 </details>

--- a/ci/run_docker_with_cpu.sh
+++ b/ci/run_docker_with_cpu.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE=rust:1.80
+IMAGE=rust:1.81
 
 # If you don't have a GPU instance configured in your machine
 docker run -v "$PWD":/src -w /src --privileged -it "$IMAGE"

--- a/ci/run_docker_with_gpu.sh
+++ b/ci/run_docker_with_gpu.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE=rust:1.80
+IMAGE=rust:1.81
 
 # If you have a GPU instance configured in your machine
 docker run -v "$PWD":/src -w /src --gpus all --privileged -it "$IMAGE"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!     <img alt="crates.io version" src="https://img.shields.io/crates/v/blitzar.svg">
 //!   </a>
 //!   <a href="https://www.rust-lang.org/">
-//!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.80-blue">
+//!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.81-blue">
 //!  </a>
 //!  <a href="https://developer.nvidia.com/cuda-downloads">
 //!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">


### PR DESCRIPTION
# Rationale for this change
In an effort to keep `blitzar-rs` up-to-date, the rust version is bumped to version `1.81`.

# What changes are included in this PR?
- Rust version is bumped from `1.80` to `1.81`

# Are these changes tested?
Yes
