### PR TITLE
feat: default send and sync for msmhandle

### DIFF
--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -22,6 +22,9 @@ pub struct MsmHandle<T: CurveId> {
     phantom: PhantomData<T>,
 }
 
+unsafe impl<T: CurveId> Send for MsmHandle<T> {}
+unsafe impl<T: CurveId> Sync for MsmHandle<T> {}
+
 impl<T: CurveId> MsmHandle<T> {
     /// New handle from the specified generators.
     ///


### PR DESCRIPTION
# Rationale for this change

Attempting to access 

```rust
*mut blitzar_sys::sxt_multiexp_handle
```

in async code blocks in rust presents the following:

```
error[E0277]: `*mut blitzar_sys::sxt_multiexp_handle` cannot be shared between threads safely
   --> proofs-service/src/libs/services/src/prover/service.rs:34:42
    |
34  | impl<'a> core::prover_server::Prover for Prover<'a> {
    |                                          ^^^^^^^^^^ `*mut blitzar_sys::sxt_multiexp_handle` cannot be shared between threads safely
    |
    = help: within `prover::service::Prover<'a>`, the trait `Sync` is not implemented for `*mut blitzar_sys::sxt_multiexp_handle`, which is required by `prover::service::Prover<'a>: Sync`
note: required because it appears within the type `blitzar::compute::fixed_msm::MsmHandle<blitzar::compute::element_p2::ElementP2<ark_bls12_381::curves::g1::Config>>`
   --> /home/debian/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blitzar-3.2.3/src/compute/fixed_msm.rs:20:12
    |
20  | pub struct MsmHandle<T: CurveId> {
    |            ^^^^^^^^^
note: required because it appears within the type `ProverSetup<'a>`
   --> /home/debian/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proof-of-sql-0.21.4/src/proof_primitive/dory/setup.rs:16:12
    |
16  | pub struct ProverSetup<'a> {
    |            ^^^^^^^^^^^
note: required because it appears within the type `prover::service::Prover<'a>`
   --> proofs-service/src/libs/services/src/prover/service.rs:16:12
    |
16  | pub struct Prover<'a> {
    |            ^^^^^^
note: required by a bound in `lib_protos::core::prover_server::Prover`
   --> /home/debian/Documents/Software/sxt-db/target/debug/build/lib-protos-a81b31c0599109fa/out/sxt.core.rs:223:30
    |
223 |     pub trait Prover: Send + Sync + 'static {
    |                              ^^^^ required by this bound in `Prover`
```

The [rustonomicon](https://doc.rust-lang.org/nomicon/send-and-sync.html) recommends providing default impls for Send and Sync for types containing raw pointers and suggests it is generally safe to do so, which should resolve this issue and allow types containing raw pointers to be used in sxt-db async code.

# What changes are included in this PR?

Provide default impls for Send and Sync on MsmHandle

# Are these changes tested?

existing tests pass
