### PR TITLE
feat: support serialization of MsmHandle to a file (PROOF-920)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ark-ff = { version = "0.4.0" }
 ark-serialize = { version = "0.4.2" }
 ark-std = { version = "0.4.0" }
 rayon = { version = "1.5" }
-blitzar-sys = { version = "1.78.0" }
+blitzar-sys = { version = "1.81.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ criterion = { version = "0.3", features = ["html_reports"] }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 rand = "0.8"
 rand_core = "0.6"
+tempfile = "3.13.0"
 
 [[bench]]
 harness = false

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -66,6 +66,20 @@ impl<T: CurveId> MsmHandle<T> {
         }
     }
 
+    /// Serialize the handle to a file.
+    ///
+    /// This function can be used together with new_from_file to reduce
+    /// the cost of creating a handle.
+    pub fn write(&self, filename: &str) {
+        let filename = CString::new(filename).expect("filename cannot have null bytes");
+        unsafe {
+            blitzar_sys::sxt_multiexp_handle_write_to_file(
+                self.handle,
+                filename.as_ptr(),
+            );
+        }
+    }
+
     /// Compute an MSM using pre-specified generators.
     ///
     /// Suppose g_1, ..., g_n are pre-specified generators and

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -2,8 +2,7 @@ use super::backend::init_backend;
 use crate::compute::{curve::SwCurveConfig, CurveId, ElementP2};
 use ark_ec::short_weierstrass::Affine;
 use rayon::prelude::*;
-use std::ffi::CString;
-use std::marker::PhantomData;
+use std::{ffi::CString, marker::PhantomData};
 
 fn count_scalars_per_output(scalars_len: usize, output_bit_table: &[u32]) -> u32 {
     let bit_sum: usize = output_bit_table.iter().map(|s| *s as usize).sum();

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -2,8 +2,8 @@ use super::backend::init_backend;
 use crate::compute::{curve::SwCurveConfig, CurveId, ElementP2};
 use ark_ec::short_weierstrass::Affine;
 use rayon::prelude::*;
-use std::marker::PhantomData;
 use std::ffi::CString;
+use std::marker::PhantomData;
 
 fn count_scalars_per_output(scalars_len: usize, output_bit_table: &[u32]) -> u32 {
     let bit_sum: usize = output_bit_table.iter().map(|s| *s as usize).sum();
@@ -55,10 +55,8 @@ impl<T: CurveId> MsmHandle<T> {
         init_backend();
         let filename = CString::new(filename).expect("filename cannot have null bytes");
         unsafe {
-            let handle = blitzar_sys::sxt_multiexp_handle_new_from_file(
-                T::CURVE_ID,
-                filename.as_ptr(),
-            );
+            let handle =
+                blitzar_sys::sxt_multiexp_handle_new_from_file(T::CURVE_ID, filename.as_ptr());
             Self {
                 handle,
                 phantom: PhantomData,
@@ -73,10 +71,7 @@ impl<T: CurveId> MsmHandle<T> {
     pub fn write(&self, filename: &str) {
         let filename = CString::new(filename).expect("filename cannot have null bytes");
         unsafe {
-            blitzar_sys::sxt_multiexp_handle_write_to_file(
-                self.handle,
-                filename.as_ptr(),
-            );
+            blitzar_sys::sxt_multiexp_handle_write_to_file(self.handle, filename.as_ptr());
         }
     }
 

--- a/src/compute/fixed_msm_tests.rs
+++ b/src/compute/fixed_msm_tests.rs
@@ -69,7 +69,7 @@ fn we_can_serialize_a_handle_to_a_file() {
 
     // read the handle back from file
     let handle = MsmHandle::<RistrettoPoint>::new_from_file(&filename);
-    
+
     // we can compute a multiexponentiation
     let scalars: Vec<u8> = vec![1, 2];
     handle.msm(&mut res, 1, &scalars);


### PR DESCRIPTION
# Rationale for this change

Support serializing an MsmHandle to a file for cheaper handle construction.

# What changes are included in this PR?

Adds two new methods new_from_handle and write to read and write an MsmHandle to file.

# Are these changes tested?

Yes
