### PR TITLE
build!: upgrade arkworks to version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ exclude = [
 documentation = "https://docs.rs/blitzar"
 
 [dependencies]
-ark-bls12-381 = { version = "0.4.0" }
-ark-bn254 = { version = "0.4.0" }
-ark-ec = { version = "0.4.0" }
-ark-ff = { version = "0.4.0" }
-ark-serialize = { version = "0.4.2" }
-ark-std = { version = "0.4.0" }
+ark-bls12-381 = { version = "0.5.0" }
+ark-bn254 = { version = "0.5.0" }
+ark-ec = { version = "0.5.0" }
+ark-ff = { version = "0.5.0" }
+ark-serialize = { version = "0.5.0" }
+ark-std = { version = "0.5.0" }
 rayon = { version = "1.5" }
 blitzar-sys = { version = "1.81.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }


### PR DESCRIPTION
# Rationale for this change
Arkworks release a new crate version - `0.5.0`. This PR upgrades the crates to use the latest version.

# What changes are included in this PR?
- All arkworks related creates are upgraded to `0.5.0`

# Are these changes tested?
Yes, locally using `cargo test` and in CI. Benchmarks have not been run on the update.