### PR TITLE
feat!: placeholder to bump major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@
 Blitzar was created by the core cryptography team at [Space and Time](https://www.spaceandtime.io/) to accelerate Proof of SQL, a novel zero-knowledge proof for SQL operations. After surveying our options for a GPU acceleration framework, we realized that Proof of SQL needed something better… so we built Blitzar. Now, Proof of SQL runs with a 3.2 second proving time against a million-row table on a single GPU, and it’s only getting faster.
 
 We’ve open-sourced Blitzar to provide the Web3 community with a faster and more
-robust framework for building GPU-accelerated zk-proofs. We’re excited to open
+robust framework for building GPU-accelerated ZK proofs. We’re excited to open
 the project to community contributions to expand the scope of Blitzar and lay
-the foundation for the next wave of lightning fast zk-proofs.
+the foundation for the next wave of lightning fast ZK proofs.
 
 #### Overview
 Blitzar-rs is a High-Level rust wrapper for the [blitzar-sys crate](https://github.com/spaceandtimelabs/blitzar/tree/main/rust/blitzar-sys) for accelerating cryptographic zero-knowledge proof algorithms on the CPU and GPU.
@@ -80,7 +80,7 @@ The crate provides
 for production use.
 
 #### Computational Backends
-Although the primary goal of this library is to provide GPU acceleration for cryptographic zk-proof algorithms, the library also provides CPU support for the sake of testing. The following backends are supported:
+Although the primary goal of this library is to provide GPU acceleration for cryptographic ZK proof algorithms, the library also provides CPU support for the sake of testing. The following backends are supported:
 
 | Backend            | Implementation                                             | Target Hardware             |
 | :---               | :---                                                       | :---                        |


### PR DESCRIPTION
# Rationale for this change
The last commit needed a major version bump, but `build!` only bumped the PATCH version. This is a placeholder commit to create a MAJOR version bump. 

To create a PR, the `README.md` updates `zk-proof` to `ZK proof`. This makes the file consistent with `blitzar`.

# What changes are included in this PR?
- `zk-proof` is updated to `ZK proof` in the `README.md`

# Are these changes tested?
Yes
