### PR TITLE
refactor: update names to match Rust conventions

### DIFF
--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -15,8 +15,8 @@
 use super::backend::init_backend;
 use crate::sequence::Sequence;
 use ark_bls12_381::G1Affine;
-use ark_bn254::G1Affine as bn254_g1_affine;
-use ark_grumpkin::Affine as grumpkin_affine;
+use ark_bn254::G1Affine as Bn254G1Affine;
+use ark_grumpkin::Affine as GrumpkinAffine;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 
 #[doc = include_str!("../../docs/commitments/compute_curve25519_commitments.md")]
@@ -148,9 +148,9 @@ pub fn compute_bls12_381_g1_commitments_with_generators(
 #[doc = include_str!("../../examples/pass_bn254_g1_generators_to_commitment.rs")]
 ///```
 pub fn compute_bn254_g1_uncompressed_commitments_with_generators(
-    commitments: &mut [bn254_g1_affine],
+    commitments: &mut [Bn254G1Affine],
     data: &[Sequence],
-    generators: &[bn254_g1_affine],
+    generators: &[Bn254G1Affine],
 ) {
     init_backend();
 
@@ -217,9 +217,9 @@ pub fn update_curve25519_commitments(
 #[doc = include_str!("../../examples/pass_grumpkin_generators_to_commitment.rs")]
 ///```
 pub fn compute_grumpkin_uncompressed_commitments_with_generators(
-    commitments: &mut [grumpkin_affine],
+    commitments: &mut [GrumpkinAffine],
     data: &[Sequence],
-    generators: &[grumpkin_affine],
+    generators: &[GrumpkinAffine],
 ) {
     init_backend();
 

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -16,9 +16,7 @@ use super::*;
 use ark_bls12_381::{Fr, G1Affine, G1Projective};
 use ark_bn254::{Fr as bn254_fr, G1Affine as Bn254G1Affine, G1Projective as Bn254G1Projective};
 use ark_ec::{CurveGroup, VariableBaseMSM};
-use ark_grumpkin::{
-    Affine as GrumpkinAffine, Fr as GrumpkinFr, Projective as GrumpkinProjective,
-};
+use ark_grumpkin::{Affine as GrumpkinAffine, Fr as GrumpkinFr, Projective as GrumpkinProjective};
 use ark_serialize::CanonicalSerialize;
 use ark_std::UniformRand;
 use curve25519_dalek::{

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -14,10 +14,10 @@
 
 use super::*;
 use ark_bls12_381::{Fr, G1Affine, G1Projective};
-use ark_bn254::{Fr as bn254_fr, G1Affine as bn254_g1_affine, G1Projective as bn254_g1_projective};
+use ark_bn254::{Fr as bn254_fr, G1Affine as Bn254G1Affine, G1Projective as Bn254G1Projective};
 use ark_ec::{CurveGroup, VariableBaseMSM};
 use ark_grumpkin::{
-    Affine as grumpkin_affine, Fr as grumpkin_fr, Projective as grumpkin_projective,
+    Affine as GrumpkinAffine, Fr as GrumpkinFr, Projective as GrumpkinProjective,
 };
 use ark_serialize::CanonicalSerialize;
 use ark_std::UniformRand;
@@ -519,12 +519,12 @@ fn sending_generators_to_gpu_produces_correct_bn254_g1_commitment_results() {
 
     // randomly obtain the generator points
     let mut rng = ark_std::test_rng();
-    let generator_points: Vec<bn254_g1_affine> = (0..data.len())
-        .map(|_| bn254_g1_affine::rand(&mut rng))
+    let generator_points: Vec<Bn254G1Affine> = (0..data.len())
+        .map(|_| Bn254G1Affine::rand(&mut rng))
         .collect();
 
     // initialize commitments
-    let mut commitments = vec![bn254_g1_affine::default(); 1];
+    let mut commitments = vec![Bn254G1Affine::default(); 1];
 
     // compute commitment in Blitzar
     compute_bn254_g1_uncompressed_commitments_with_generators(
@@ -540,11 +540,11 @@ fn sending_generators_to_gpu_produces_correct_bn254_g1_commitment_results() {
     }
 
     // compute msm in Arkworks
-    let ark_commitment = bn254_g1_projective::msm(&generator_points, &scalar_data).unwrap();
+    let ark_commitment = Bn254G1Projective::msm(&generator_points, &scalar_data).unwrap();
 
     // verify results
     assert_eq!(commitments[0], ark_commitment.into_affine());
-    assert_ne!(bn254_g1_affine::default(), commitments[0]);
+    assert_ne!(Bn254G1Affine::default(), commitments[0]);
 }
 
 #[test]
@@ -554,12 +554,12 @@ fn sending_generators_to_gpu_produces_correct_grumpkin_commitment_results() {
 
     // randomly obtain the generator points
     let mut rng = ark_std::test_rng();
-    let generator_points: Vec<grumpkin_affine> = (0..data.len())
-        .map(|_| grumpkin_affine::rand(&mut rng))
+    let generator_points: Vec<GrumpkinAffine> = (0..data.len())
+        .map(|_| GrumpkinAffine::rand(&mut rng))
         .collect();
 
     // initialize commitments
-    let mut commitments = vec![grumpkin_affine::default(); 1];
+    let mut commitments = vec![GrumpkinAffine::default(); 1];
 
     // compute commitment in Blitzar
     compute_grumpkin_uncompressed_commitments_with_generators(
@@ -569,19 +569,19 @@ fn sending_generators_to_gpu_produces_correct_grumpkin_commitment_results() {
     );
 
     // convert data to scalar
-    let mut scalar_data: Vec<grumpkin_fr> = Vec::new();
+    let mut scalar_data: Vec<GrumpkinFr> = Vec::new();
     for d in &data {
-        scalar_data.push(grumpkin_fr::from(*d));
+        scalar_data.push(GrumpkinFr::from(*d));
     }
 
     // compute msm in Arkworks
-    let ark_commitment = grumpkin_projective::msm(&generator_points, &scalar_data)
+    let ark_commitment = GrumpkinProjective::msm(&generator_points, &scalar_data)
         .unwrap()
         .into_affine();
 
     // verify results
     assert_eq!(commitments[0], ark_commitment);
-    assert_ne!(grumpkin_affine::default(), commitments[0]);
+    assert_ne!(GrumpkinAffine::default(), commitments[0]);
 }
 
 #[test]


### PR DESCRIPTION
# Rationale for this change
A few names do not match the Rust camel case convention. This PR addresses the names found in the commitments module.

# What changes are included in this PR?
- Names are updated to match Rust conventions.

# Are these changes tested?
Yes