### PR TITLE
ci: update to self hosted runner to control Nvidia driver

### DIFF
--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-code:
     name: Check Code
-    runs-on: nvidia-nc4as-t4
+    runs-on: public-blitzar-T4-gpu-vm
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -33,7 +33,7 @@ jobs:
 
   clippy-code:
     name: Clippy Code
-    runs-on: nvidia-nc4as-t4
+    runs-on: public-blitzar-T4-gpu-vm
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -51,7 +51,7 @@ jobs:
 
   test-cpu:
     name: Test the CPU backend
-    runs-on: nvidia-nc4as-t4
+    runs-on: public-blitzar-T4-gpu-vm
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -67,7 +67,7 @@ jobs:
 
   test-gpu:
     name: Test the GPU backend
-    runs-on: nvidia-nc4as-t4
+    runs-on: public-blitzar-T4-gpu-vm
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-code:
     name: Check Code
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: self-hosted
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -33,7 +33,7 @@ jobs:
 
   clippy-code:
     name: Clippy Code
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: self-hosted
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -51,7 +51,7 @@ jobs:
 
   test-cpu:
     name: Test the CPU backend
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: self-hosted
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -67,7 +67,7 @@ jobs:
 
   test-gpu:
     name: Test the GPU backend
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: self-hosted
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -78,14 +78,5 @@ jobs:
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
-      - name: Install Dependencies
-        run: |
-          export DEBIAN_FRONTEND=non-interactive
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository ppa:graphics-drivers/ppa
-          sudo apt-get update
-          sudo apt-get install -y nvidia-open-560
-
       - name: Run GPU test
         run: cargo test --features gpu


### PR DESCRIPTION
# Rationale for this change
The Github hosted runner might be dependent on Azure/Actions creating a new release, the latest one is `NVIDIA vGPU Driver 550.127.05`. https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-azure/index.html#azure-vmi-aie-relnote

This does not meet the `blitzar` Nvidia driver requirement of `560`.  The Github runner did support Nvidia driver version `560`, but something changed on January 25, 2025. This is a workaround to unblock the `blitzar-rs` CI.

# What changes are included in this PR?
- CI will now run on the self hosted blitzar runner

# Are these changes tested?
Yes