### PR TITLE
bench: add simple Jaeger benchmarks to project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,17 @@ ark-ff = { version = "0.5.0" }
 ark-grumpkin = { version = "0.5.0" }
 ark-serialize = { version = "0.5.0" }
 ark-std = { version = "0.5.0" }
+opentelemetry = { version = "0.23.0" }
+opentelemetry-jaeger = { version = "0.20.0" }
 rayon = { version = "1.5" }
 blitzar-sys = { version = "1.81.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
+tracing = { version = "0.1.36", features = ["attributes"] }
+tracing-opentelemetry = { version = "0.22.0" }
+tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 
 # this sections is shared by tests, benchmarks, and examples
 [dev-dependencies]
@@ -39,6 +44,10 @@ tempfile = "3.13.0"
 [[bench]]
 harness = false
 name = "blitzar_benchmarks"
+
+[[bench]]
+harness = false
+name = "jaeger_benches"
 
 [[bench]]
 harness = false

--- a/benches/jaeger_benches.rs
+++ b/benches/jaeger_benches.rs
@@ -1,0 +1,222 @@
+// Copyright 2025-present Space and Time Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Benchmarking/Tracing using Jaeger.
+//! To run, execute the following commands:
+//! ```bash
+//! docker run --rm -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:1.62.0
+//! cargo bench --bench jaeger_benches all
+//! cargo bench --bench jaeger_benches <BENCHMARK_TYPES>
+//! ```
+//! Then, navigate to <http://localhost:16686> to view the traces.
+
+extern crate blitzar;
+use ark_bls12_381::G1Affine as Bls12381G1Affine;
+use ark_bn254::G1Affine as Bn254G1Affine;
+use ark_grumpkin::Affine as GrumpkinAffine;
+use ark_std::UniformRand;
+use blitzar::sequence::Sequence;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use rand::Rng;
+use rand_core::OsRng;
+use std::env;
+
+const LENGTH: [usize; 2] = [1024, 1 << 20];
+const NUM_OUTPUTS: [usize; 2] = [1024, 1];
+const ITERATIONS: usize = 3;
+const BENCHMARK_TYPES: &[&str] = &[
+    "compute_curve25519_commitments_with_generators",
+    "compute_bls12_381_g1_commitments_with_generators",
+    "compute_bn254_g1_uncompressed_commitments_with_generators",
+    "compute_grumpkin_uncompressed_commitments_with_generators",
+];
+
+fn run_benchmark(benchmark_type: &str) {
+    match benchmark_type {
+        "compute_curve25519_commitments_with_generators" => {
+            for (length, num_outputs) in LENGTH.iter().zip(NUM_OUTPUTS.iter()) {
+                let mut rng = OsRng;
+
+                // Generate random data
+                let scalars: Vec<Vec<u64>> = (0..*num_outputs)
+                    .map(|_| {
+                        (0..*length)
+                            .map(|_| rng.gen_range(u64::MIN..u64::MAX))
+                            .collect()
+                    })
+                    .collect();
+
+                let data: Vec<Sequence> = scalars
+                    .iter()
+                    .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                    .collect();
+
+                // Generate random generators
+                let generators: Vec<RistrettoPoint> = (0..*length)
+                    .map(|_| RistrettoPoint::random(&mut rng))
+                    .collect();
+
+                // Create commitments
+                let mut commitments = vec![CompressedRistretto::default(); *num_outputs];
+
+                for _ in 0..ITERATIONS {
+                    blitzar::compute::compute_curve25519_commitments_with_generators(
+                        &mut commitments,
+                        &data,
+                        &generators,
+                    );
+                }
+            }
+        }
+        "compute_bls12_381_g1_commitments_with_generators" => {
+            for (length, num_outputs) in LENGTH.iter().zip(NUM_OUTPUTS.iter()) {
+                let mut rng = ark_std::test_rng();
+
+                // Generate random data
+                let scalars: Vec<Vec<u64>> = (0..*num_outputs)
+                    .map(|_| {
+                        (0..*length)
+                            .map(|_| rng.gen_range(u64::MIN..u64::MAX))
+                            .collect()
+                    })
+                    .collect();
+
+                let data: Vec<Sequence> = scalars
+                    .iter()
+                    .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                    .collect();
+
+                // Generate random generators
+                let generators: Vec<Bls12381G1Affine> = (0..*length)
+                    .map(|_| Bls12381G1Affine::rand(&mut rng))
+                    .collect();
+
+                // Create commitments
+                let mut commitments = vec![[0_u8; 48]; *num_outputs];
+
+                for _ in 0..ITERATIONS {
+                    blitzar::compute::compute_bls12_381_g1_commitments_with_generators(
+                        &mut commitments,
+                        &data,
+                        &generators,
+                    );
+                }
+            }
+        }
+        "compute_bn254_g1_uncompressed_commitments_with_generators" => {
+            for (length, num_outputs) in LENGTH.iter().zip(NUM_OUTPUTS.iter()) {
+                let mut rng = ark_std::test_rng();
+
+                // Generate random data
+                let scalars: Vec<Vec<u64>> = (0..*num_outputs)
+                    .map(|_| {
+                        (0..*length)
+                            .map(|_| rng.gen_range(u64::MIN..u64::MAX))
+                            .collect()
+                    })
+                    .collect();
+
+                let data: Vec<Sequence> = scalars
+                    .iter()
+                    .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                    .collect();
+
+                // Generate random generators
+                let generators: Vec<Bn254G1Affine> = (0..*length)
+                    .map(|_| Bn254G1Affine::rand(&mut rng))
+                    .collect();
+
+                // Create commitments
+                let mut commitments = vec![Bn254G1Affine::default(); *num_outputs];
+
+                for _ in 0..ITERATIONS {
+                    blitzar::compute::compute_bn254_g1_uncompressed_commitments_with_generators(
+                        &mut commitments,
+                        &data,
+                        &generators,
+                    );
+                }
+            }
+        }
+        "compute_grumpkin_uncompressed_commitments_with_generators" => {
+            for (length, num_outputs) in LENGTH.iter().zip(NUM_OUTPUTS.iter()) {
+                let mut rng = ark_std::test_rng();
+
+                // Generate random data
+                let scalars: Vec<Vec<u64>> = (0..*num_outputs)
+                    .map(|_| {
+                        (0..*length)
+                            .map(|_| rng.gen_range(u64::MIN..u64::MAX))
+                            .collect()
+                    })
+                    .collect();
+
+                let data: Vec<Sequence> = scalars
+                    .iter()
+                    .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                    .collect();
+
+                // Generate random generators
+                let generators: Vec<GrumpkinAffine> = (0..*length)
+                    .map(|_| GrumpkinAffine::rand(&mut rng))
+                    .collect();
+
+                // Create commitments
+                let mut commitments = vec![GrumpkinAffine::default(); *num_outputs];
+
+                for _ in 0..ITERATIONS {
+                    blitzar::compute::compute_grumpkin_uncompressed_commitments_with_generators(
+                        &mut commitments,
+                        &data,
+                        &generators,
+                    );
+                }
+            }
+        }
+        _ => panic!("Invalid benchmark type specified."),
+    }
+}
+
+fn main() {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+    let tracer = opentelemetry_jaeger::new_agent_pipeline()
+        .with_service_name("benches")
+        .install_simple()
+        .unwrap();
+
+    let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("DEBUG"));
+
+    tracing_subscriber::registry()
+        .with(opentelemetry)
+        .with(filter)
+        .try_init()
+        .unwrap();
+
+    // Check for command-line arguments to select the benchmark type.
+    let args: Vec<String> = env::args().collect();
+    let benchmark_type = args
+        .get(1)
+        .expect("Please specify the benchmark type as an argument.");
+
+    if benchmark_type == "all" {
+        for &benchmark in BENCHMARK_TYPES {
+            run_benchmark(benchmark);
+        }
+    } else {
+        run_benchmark(benchmark_type);
+    }
+}

--- a/src/compute/commitments.rs
+++ b/src/compute/commitments.rs
@@ -69,6 +69,7 @@ pub fn compute_curve25519_commitments(
 ///```no_run
 #[doc = include_str!("../../examples/pass_generators_and_scalars_to_commitment.rs")]
 ///```
+#[tracing::instrument(level = "debug", skip_all, fields(num_outputs = commitments.len(), length = generators.len()))]
 pub fn compute_curve25519_commitments_with_generators(
     commitments: &mut [CompressedRistretto],
     data: &[Sequence],
@@ -108,6 +109,7 @@ pub fn compute_curve25519_commitments_with_generators(
 ///```no_run
 #[doc = include_str!("../../examples/pass_bls12_381_g1_generators_to_commitment.rs")]
 ///```
+#[tracing::instrument(level = "debug", skip_all, fields(num_outputs = commitments.len(), length = generators.len()))]
 pub fn compute_bls12_381_g1_commitments_with_generators(
     commitments: &mut [[u8; 48]],
     data: &[Sequence],
@@ -147,6 +149,7 @@ pub fn compute_bls12_381_g1_commitments_with_generators(
 ///```no_run
 #[doc = include_str!("../../examples/pass_bn254_g1_generators_to_commitment.rs")]
 ///```
+#[tracing::instrument(level = "debug", skip_all, fields(num_outputs = commitments.len(), length = generators.len()))]
 pub fn compute_bn254_g1_uncompressed_commitments_with_generators(
     commitments: &mut [Bn254G1Affine],
     data: &[Sequence],
@@ -216,6 +219,7 @@ pub fn update_curve25519_commitments(
 ///```no_run
 #[doc = include_str!("../../examples/pass_grumpkin_generators_to_commitment.rs")]
 ///```
+#[tracing::instrument(level = "debug", skip_all, fields(num_outputs = commitments.len(), length = generators.len()))]
 pub fn compute_grumpkin_uncompressed_commitments_with_generators(
     commitments: &mut [GrumpkinAffine],
     data: &[Sequence],


### PR DESCRIPTION
# Rationale for this change
This PR introduces simple Jaeger benchmarks for commitment computation with generators. This work will be useful for development of the HyperKZG related commitment computation because point conversion will need to be implemented.

Future work can allow for `length`, `num_output`, and `iteration` input. This is not a replacement of `Criterion` benchmarks.

# What changes are included in this PR?
- Jaeger benchmarks are added to the project for commitment with generator functions.

# Are these changes tested?
Yes
