### PR TITLE
bench: add new criterion benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,19 @@ tempfile = "3.13.0"
 
 [[bench]]
 harness = false
-name = "blitzar_benchmarks"
+name = "blitzar_bls12_381_benchmarks"
+
+[[bench]]
+harness = false
+name = "blitzar_bn254_benchmarks"
+
+[[bench]]
+harness = false
+name = "blitzar_curve25519_benchmarks"
+
+[[bench]]
+harness = false
+name = "blitzar_grumpkin_benchmarks"
 
 [[bench]]
 harness = false

--- a/README.md
+++ b/README.md
@@ -170,14 +170,19 @@ Check [EXAMPLES](docs/EXAMPLES.md) file.
 ### Running benchmarks:
 
 Benchmarks are run using [criterion.rs](https://github.com/bheisler/criterion.rs):
-
 ```
 cargo bench --features <cpu | gpu>
 ```
 To run individual tests:
 ```
-cargo bench --features <cpu | gpu> --bench <blitzar_benchmarks | packed_msm_benchmarks>
+cargo bench --features <cpu | gpu> --bench <benchmark_name>
 ```
+and replace the `benchmark_name` with one of the following available benchmarks
+- `blitzar_bls12_381_benchmarks`
+- `blitzar_bn254_benchmarks`
+- `blitzar_curve25519_benchmarks`
+- `blitzar_grumpkin_benchmarks`
+- `packed_msm_benchmarks`
 
 ## Development Process
 

--- a/benches/blitzar_bls12_381_benchmarks.rs
+++ b/benches/blitzar_bls12_381_benchmarks.rs
@@ -1,0 +1,140 @@
+// Copyright 2023-present Space and Time Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ark_bls12_381::{Fr, G1Affine};
+use ark_ff::BigInt;
+use ark_std::UniformRand;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+extern crate rand;
+use crate::rand::Rng;
+
+use blitzar::compute::*;
+use blitzar::sequence::*;
+
+mod blitzar_bls12_381_benchmarks {
+    use ark_ff::PrimeField;
+
+    use super::*;
+
+    fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<BigInt<4>>> {
+        let mut rng = ark_std::test_rng();
+
+        (0..num_commits)
+            .map(|_| {
+                (0..num_rows)
+                    .map(|_| Fr::rand(&mut rng).into_bigint())
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn construct_sequences_data(num_commits: usize, num_rows: usize) -> Vec<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+
+        (0..num_commits)
+            .map(|_| ((0..num_rows).map(|_| rng.gen::<u8>()).collect()))
+            .collect()
+    }
+
+    fn construct_generators(num_commits: usize) -> Vec<G1Affine> {
+        let mut rng = ark_std::test_rng();
+        (0..num_commits).map(|_| G1Affine::rand(&mut rng)).collect()
+    }
+
+    fn run_computation(num_commits: usize, num_rows: usize, c: &mut Criterion, use_scalars: bool) {
+        let generators = construct_generators(num_rows);
+        let mut commitments = vec![[0_u8; 48]; num_commits];
+
+        let benchmark_label: String = "bls12_381_g1 ".to_string();
+        let num_commits_label: String = num_commits.to_string() + " commits";
+        let benchmark_group_label: String = benchmark_label + &num_commits_label;
+
+        let with_generators_label: String = num_rows.to_string()
+            + " rows"
+            + " - use scalars ("
+            + if use_scalars { "yes" } else { "no" }
+            + ")";
+
+        let mut group = c.benchmark_group(&benchmark_group_label);
+
+        group.throughput(criterion::Throughput::Elements(
+            (num_commits * num_rows) as u64,
+        ));
+
+        if use_scalars {
+            let data = construct_scalars_data(num_commits, num_rows);
+            let table: Vec<Sequence> = data
+                .iter()
+                .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                .collect();
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_bls12_381_g1_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        } else {
+            let data = construct_sequences_data(num_commits, num_rows);
+            let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_bls12_381_g1_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        }
+
+        group.finish();
+    }
+
+    fn batch_commitment_computation_with_scalars(c: &mut Criterion) {
+        init_backend();
+
+        let bench_runs = vec![
+            (1, vec![1, 10, 100, 1000, 10000, 100000]), // 1 commits
+            (10, vec![10, 100, 1000]),                  // 10 commits
+            (100, vec![10, 100, 1000]),                 // 100 commits
+            (1000, vec![10, 100, 1000]),                // 1000 commits
+        ];
+
+        // iterate through the num_commits
+        for curr_bench in bench_runs {
+            // iterate through the num_rows
+            for i in curr_bench.1 {
+                run_computation(curr_bench.0, i, c, false);
+                run_computation(curr_bench.0, i, c, true);
+            }
+        }
+    }
+
+    criterion_group! {
+        name = blitzar_compute_bls12_381_g1_commitments;
+        // Lower the sample size to run the benchmarks faster
+        config = Criterion::default().sample_size(15);
+        targets =
+            batch_commitment_computation_with_scalars
+    }
+}
+
+criterion_main!(blitzar_bls12_381_benchmarks::blitzar_compute_bls12_381_g1_commitments);

--- a/benches/blitzar_bls12_381_benchmarks.rs
+++ b/benches/blitzar_bls12_381_benchmarks.rs
@@ -15,19 +15,15 @@
 use ark_bls12_381::{Fr, G1Affine};
 use ark_ff::BigInt;
 use ark_std::UniformRand;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate rand;
 use crate::rand::Rng;
-
-use blitzar::compute::*;
-use blitzar::sequence::*;
+use blitzar::{compute::*, sequence::*};
 
 mod blitzar_bls12_381_benchmarks {
-    use ark_ff::PrimeField;
-
     use super::*;
+    use ark_ff::PrimeField;
 
     fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<BigInt<4>>> {
         let mut rng = ark_std::test_rng();

--- a/benches/blitzar_bn254_benchmarks.rs
+++ b/benches/blitzar_bn254_benchmarks.rs
@@ -15,19 +15,15 @@
 use ark_bn254::{Fr, G1Affine};
 use ark_ff::BigInt;
 use ark_std::UniformRand;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate rand;
 use crate::rand::Rng;
-
-use blitzar::compute::*;
-use blitzar::sequence::*;
+use blitzar::{compute::*, sequence::*};
 
 mod blitzar_bn254_benchmarks {
-    use ark_ff::PrimeField;
-
     use super::*;
+    use ark_ff::PrimeField;
 
     fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<BigInt<4>>> {
         let mut rng = ark_std::test_rng();

--- a/benches/blitzar_bn254_benchmarks.rs
+++ b/benches/blitzar_bn254_benchmarks.rs
@@ -1,0 +1,140 @@
+// Copyright 2023-present Space and Time Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ark_bn254::{Fr, G1Affine};
+use ark_ff::BigInt;
+use ark_std::UniformRand;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+extern crate rand;
+use crate::rand::Rng;
+
+use blitzar::compute::*;
+use blitzar::sequence::*;
+
+mod blitzar_bn254_benchmarks {
+    use ark_ff::PrimeField;
+
+    use super::*;
+
+    fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<BigInt<4>>> {
+        let mut rng = ark_std::test_rng();
+
+        (0..num_commits)
+            .map(|_| {
+                (0..num_rows)
+                    .map(|_| Fr::rand(&mut rng).into_bigint())
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn construct_sequences_data(num_commits: usize, num_rows: usize) -> Vec<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+
+        (0..num_commits)
+            .map(|_| ((0..num_rows).map(|_| rng.gen::<u8>()).collect()))
+            .collect()
+    }
+
+    fn construct_generators(num_commits: usize) -> Vec<G1Affine> {
+        let mut rng = ark_std::test_rng();
+        (0..num_commits).map(|_| G1Affine::rand(&mut rng)).collect()
+    }
+
+    fn run_computation(num_commits: usize, num_rows: usize, c: &mut Criterion, use_scalars: bool) {
+        let generators = construct_generators(num_rows);
+        let mut commitments = vec![G1Affine::default(); num_commits];
+
+        let benchmark_label: String = "bn254_g1 ".to_string();
+        let num_commits_label: String = num_commits.to_string() + " commits";
+        let benchmark_group_label: String = benchmark_label + &num_commits_label;
+
+        let with_generators_label: String = num_rows.to_string()
+            + " rows"
+            + " - use scalars ("
+            + if use_scalars { "yes" } else { "no" }
+            + ")";
+
+        let mut group = c.benchmark_group(&benchmark_group_label);
+
+        group.throughput(criterion::Throughput::Elements(
+            (num_commits * num_rows) as u64,
+        ));
+
+        if use_scalars {
+            let data = construct_scalars_data(num_commits, num_rows);
+            let table: Vec<Sequence> = data
+                .iter()
+                .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                .collect();
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_bn254_g1_uncompressed_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        } else {
+            let data = construct_sequences_data(num_commits, num_rows);
+            let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_bn254_g1_uncompressed_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        }
+
+        group.finish();
+    }
+
+    fn batch_commitment_computation_with_scalars(c: &mut Criterion) {
+        init_backend();
+
+        let bench_runs = vec![
+            (1, vec![1, 10, 100, 1000, 10000, 100000]), // 1 commits
+            (10, vec![10, 100, 1000]),                  // 10 commits
+            (100, vec![10, 100, 1000]),                 // 100 commits
+            (1000, vec![10, 100, 1000]),                // 1000 commits
+        ];
+
+        // iterate through the num_commits
+        for curr_bench in bench_runs {
+            // iterate through the num_rows
+            for i in curr_bench.1 {
+                run_computation(curr_bench.0, i, c, false);
+                run_computation(curr_bench.0, i, c, true);
+            }
+        }
+    }
+
+    criterion_group! {
+        name = blitzar_compute_bn254_g1_commitments;
+        // Lower the sample size to run the benchmarks faster
+        config = Criterion::default().sample_size(15);
+        targets =
+            batch_commitment_computation_with_scalars
+    }
+}
+
+criterion_main!(blitzar_bn254_benchmarks::blitzar_compute_bn254_g1_commitments);

--- a/benches/blitzar_curve25519_benchmarks.rs
+++ b/benches/blitzar_curve25519_benchmarks.rs
@@ -1,0 +1,150 @@
+// Copyright 2023-present Space and Time Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate rand;
+
+use crate::rand::Rng;
+use blitzar::{compute::*, sequence::Sequence};
+use criterion::{criterion_group, criterion_main, Criterion};
+use curve25519_dalek::{
+    constants,
+    ristretto::{CompressedRistretto, RistrettoPoint},
+    scalar::Scalar,
+};
+use rand::thread_rng;
+
+mod blitzar_curve25519_benchmarks {
+    use super::*;
+
+    fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<Scalar>> {
+        let mut rng = thread_rng();
+
+        (0..num_commits)
+            .map(|_| ((0..num_rows).map(|_| Scalar::random(&mut rng)).collect()))
+            .collect()
+    }
+
+    fn construct_sequences_data(num_commits: usize, num_rows: usize) -> Vec<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+
+        (0..num_commits)
+            .map(|_| ((0..num_rows).map(|_| rng.gen::<u8>()).collect()))
+            .collect()
+    }
+
+    fn construct_generators(n: usize) -> Vec<RistrettoPoint> {
+        let mut rng = thread_rng();
+        (0..n)
+            .map(|_| (&Scalar::random(&mut rng) * constants::RISTRETTO_BASEPOINT_TABLE))
+            .collect()
+    }
+
+    fn run_computation(num_commits: usize, num_rows: usize, c: &mut Criterion, use_scalars: bool) {
+        let generators = construct_generators(num_rows);
+        let mut commitments = vec![CompressedRistretto::default(); num_commits];
+
+        let benchmark_label: String = "curve25519 ".to_string();
+        let num_commits_label: String = num_commits.to_string() + " commits";
+        let benchmark_group_label: String = benchmark_label + &num_commits_label;
+
+        let without_generators_label: String = num_rows.to_string()
+            + " rows"
+            + " - use scalars ("
+            + if use_scalars { "yes" } else { "no" }
+            + ") - use generators (no)";
+
+        let with_generators_label: String = num_rows.to_string()
+            + " rows"
+            + " - use scalars ("
+            + if use_scalars { "yes" } else { "no" }
+            + ") - use generators (yes)";
+
+        let mut group = c.benchmark_group(&benchmark_group_label);
+
+        group.throughput(criterion::Throughput::Elements(
+            (num_commits * num_rows) as u64,
+        ));
+
+        if use_scalars {
+            let data = construct_scalars_data(num_commits, num_rows);
+            let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
+
+            group.bench_function(
+                &without_generators_label,
+                |b: &mut criterion::Bencher<'_>| {
+                    b.iter(|| compute_curve25519_commitments(&mut commitments, &table, 0_u64))
+                },
+            );
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_curve25519_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        } else {
+            let data = construct_sequences_data(num_commits, num_rows);
+            let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
+
+            group.bench_function(&without_generators_label, |b| {
+                b.iter(|| compute_curve25519_commitments(&mut commitments, &table, 0_u64))
+            });
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_curve25519_commitments_with_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        }
+
+        group.finish();
+    }
+
+    fn batch_commitment_computation_with_scalars(c: &mut Criterion) {
+        init_backend();
+
+        let bench_runs = vec![
+            (1, vec![1, 10, 100, 1000, 10000, 100000]), // 1 commits
+            (10, vec![10, 100, 1000]),                  // 10 commits
+            (100, vec![10, 100, 1000]),                 // 100 commits
+            (1000, vec![10, 100, 1000]),                // 1000 commits
+        ];
+
+        // iterate through the num_commits
+        for curr_bench in bench_runs {
+            // iterate through the num_rows
+            for i in curr_bench.1 {
+                run_computation(curr_bench.0, i, c, false);
+                run_computation(curr_bench.0, i, c, true);
+            }
+        }
+    }
+
+    criterion_group! {
+        name = blitzar_compute_curve25519_commitments;
+        // Lower the sample size to run the benchmarks faster
+        config = Criterion::default().sample_size(15);
+        targets =
+            batch_commitment_computation_with_scalars
+    }
+}
+
+criterion_main!(blitzar_curve25519_benchmarks::blitzar_compute_curve25519_commitments);

--- a/benches/blitzar_grumpkin_benchmarks.rs
+++ b/benches/blitzar_grumpkin_benchmarks.rs
@@ -15,19 +15,15 @@
 use ark_ff::BigInt;
 use ark_grumpkin::{Affine, Fr};
 use ark_std::UniformRand;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate rand;
 use crate::rand::Rng;
-
-use blitzar::compute::*;
-use blitzar::sequence::*;
+use blitzar::{compute::*, sequence::*};
 
 mod blitzar_grumpkin_benchmarks {
-    use ark_ff::PrimeField;
-
     use super::*;
+    use ark_ff::PrimeField;
 
     fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<BigInt<4>>> {
         let mut rng = ark_std::test_rng();

--- a/benches/blitzar_grumpkin_benchmarks.rs
+++ b/benches/blitzar_grumpkin_benchmarks.rs
@@ -12,26 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate rand;
+use ark_ff::BigInt;
+use ark_grumpkin::{Affine, Fr};
+use ark_std::UniformRand;
 
-use crate::rand::Rng;
-use blitzar::{compute::*, sequence::Sequence};
 use criterion::{criterion_group, criterion_main, Criterion};
-use curve25519_dalek::{
-    constants,
-    ristretto::{CompressedRistretto, RistrettoPoint},
-    scalar::Scalar,
-};
-use rand::thread_rng;
 
-mod blitzar_benches {
+extern crate rand;
+use crate::rand::Rng;
+
+use blitzar::compute::*;
+use blitzar::sequence::*;
+
+mod blitzar_grumpkin_benchmarks {
+    use ark_ff::PrimeField;
+
     use super::*;
 
-    fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<Scalar>> {
-        let mut rng = thread_rng();
+    fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<BigInt<4>>> {
+        let mut rng = ark_std::test_rng();
 
         (0..num_commits)
-            .map(|_| ((0..num_rows).map(|_| Scalar::random(&mut rng)).collect()))
+            .map(|_| {
+                (0..num_rows)
+                    .map(|_| Fr::rand(&mut rng).into_bigint())
+                    .collect()
+            })
             .collect()
     }
 
@@ -43,32 +49,26 @@ mod blitzar_benches {
             .collect()
     }
 
-    fn construct_generators(n: usize) -> Vec<RistrettoPoint> {
-        let mut rng = thread_rng();
-        (0..n)
-            .map(|_| (&Scalar::random(&mut rng) * constants::RISTRETTO_BASEPOINT_TABLE))
-            .collect()
+    fn construct_generators(num_commits: usize) -> Vec<Affine> {
+        let mut rng = ark_std::test_rng();
+        (0..num_commits).map(|_| Affine::rand(&mut rng)).collect()
     }
 
     fn run_computation(num_commits: usize, num_rows: usize, c: &mut Criterion, use_scalars: bool) {
         let generators = construct_generators(num_rows);
-        let mut commitments = vec![CompressedRistretto::default(); num_commits];
+        let mut commitments = vec![Affine::default(); num_commits];
 
+        let benchmark_label: String = "grumpkin ".to_string();
         let num_commits_label: String = num_commits.to_string() + " commits";
-
-        let without_generators_label: String = num_rows.to_string()
-            + " rows"
-            + " - use scalars ("
-            + if use_scalars { "yes" } else { "no" }
-            + ") - use generators (no)";
+        let benchmark_group_label: String = benchmark_label + &num_commits_label;
 
         let with_generators_label: String = num_rows.to_string()
             + " rows"
             + " - use scalars ("
             + if use_scalars { "yes" } else { "no" }
-            + ") - use generators (yes)";
+            + ")";
 
-        let mut group = c.benchmark_group(&num_commits_label);
+        let mut group = c.benchmark_group(&benchmark_group_label);
 
         group.throughput(criterion::Throughput::Elements(
             (num_commits * num_rows) as u64,
@@ -76,18 +76,14 @@ mod blitzar_benches {
 
         if use_scalars {
             let data = construct_scalars_data(num_commits, num_rows);
-            let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
-
-            group.bench_function(
-                &without_generators_label,
-                |b: &mut criterion::Bencher<'_>| {
-                    b.iter(|| compute_curve25519_commitments(&mut commitments, &table, 0_u64))
-                },
-            );
+            let table: Vec<Sequence> = data
+                .iter()
+                .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                .collect();
 
             group.bench_function(&with_generators_label, |b| {
                 b.iter(|| {
-                    compute_curve25519_commitments_with_generators(
+                    compute_grumpkin_uncompressed_commitments_with_generators(
                         &mut commitments,
                         &table,
                         &generators,
@@ -98,13 +94,9 @@ mod blitzar_benches {
             let data = construct_sequences_data(num_commits, num_rows);
             let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
 
-            group.bench_function(&without_generators_label, |b| {
-                b.iter(|| compute_curve25519_commitments(&mut commitments, &table, 0_u64))
-            });
-
             group.bench_function(&with_generators_label, |b| {
                 b.iter(|| {
-                    compute_curve25519_commitments_with_generators(
+                    compute_grumpkin_uncompressed_commitments_with_generators(
                         &mut commitments,
                         &table,
                         &generators,
@@ -137,7 +129,7 @@ mod blitzar_benches {
     }
 
     criterion_group! {
-        name = blitzar_compute_commitments;
+        name = blitzar_compute_grumpkin_commitments;
         // Lower the sample size to run the benchmarks faster
         config = Criterion::default().sample_size(15);
         targets =
@@ -145,4 +137,4 @@ mod blitzar_benches {
     }
 }
 
-criterion_main!(blitzar_benches::blitzar_compute_commitments);
+criterion_main!(blitzar_grumpkin_benchmarks::blitzar_compute_grumpkin_commitments);

--- a/benches/packed_msm_benchmarks.rs
+++ b/benches/packed_msm_benchmarks.rs
@@ -15,6 +15,9 @@
 extern crate rand;
 
 use crate::rand::Rng;
+use ark_bls12_381::G1Affine as Bls12381G1Affine;
+use ark_bn254::G1Affine as Bn254G1Affine;
+use ark_std::UniformRand;
 use blitzar::compute::*;
 use criterion::{criterion_group, criterion_main, Criterion};
 use curve25519_dalek::ristretto::RistrettoPoint;
@@ -23,24 +26,22 @@ use rand_core::OsRng;
 mod packed_msm_benches {
     use super::*;
 
-    fn packed_msm_commitment_computation(c: &mut Criterion) {
-        init_backend();
+    fn bls12_381_msm_benchmark(
+        c: &mut Criterion,
+        num_commits: usize,
+        num_rows: usize,
+        bench_runs_bit_size: &[u32],
+    ) {
+        let mut rng = ark_std::test_rng();
+        let mut res = vec![ElementP2::<ark_bls12_381::g1::Config>::default(); num_commits];
 
-        let mut rng = OsRng;
-        let num_commits = 1024;
-        let num_rows = 1024;
-
-        let mut res = vec![RistrettoPoint::default(); num_commits];
-
-        let generators: Vec<RistrettoPoint> = (0..num_rows)
-            .map(|_| RistrettoPoint::random(&mut rng))
+        let generators: Vec<ElementP2<ark_bls12_381::g1::Config>> = (0..num_rows)
+            .map(|_| Bls12381G1Affine::rand(&mut rng).into())
             .collect();
 
         let handle = MsmHandle::new(&generators);
 
-        let bench_runs_bit_size = vec![256, 128, 64, 32, 16, 8, 1];
-
-        for curr_bench_bit_size in bench_runs_bit_size {
+        for &curr_bench_bit_size in bench_runs_bit_size {
             let bit_size: u32 = curr_bench_bit_size;
 
             let output_bit_table: Vec<u32> = vec![bit_size; num_rows];
@@ -54,7 +55,7 @@ mod packed_msm_benches {
             };
 
             let label = format!(
-                "New Benchmark - {} commits, {} rows, {} bit size",
+                "bls12-381 g1 packed_msm_benchmark - {} commits, {} rows, {} bit size",
                 num_commits, num_rows, bit_size
             );
 
@@ -62,6 +63,96 @@ mod packed_msm_benches {
                 b.iter(|| handle.packed_msm(&mut res, &output_bit_table, &scalars))
             });
         }
+    }
+
+    fn bn254_msm_benchmark(
+        c: &mut Criterion,
+        num_commits: usize,
+        num_rows: usize,
+        bench_runs_bit_size: &[u32],
+    ) {
+        let mut rng = ark_std::test_rng();
+        let mut res = vec![ElementP2::<ark_bn254::g1::Config>::default(); num_commits];
+
+        let generators: Vec<ElementP2<ark_bn254::g1::Config>> = (0..num_rows)
+            .map(|_| Bn254G1Affine::rand(&mut rng).into())
+            .collect();
+
+        let handle = MsmHandle::new(&generators);
+
+        for &curr_bench_bit_size in bench_runs_bit_size {
+            let bit_size: u32 = curr_bench_bit_size;
+
+            let output_bit_table: Vec<u32> = vec![bit_size; num_rows];
+
+            let scalars: Vec<u8> = if bit_size > 1 {
+                (0..num_rows * bit_size as usize)
+                    .map(|_| rng.gen::<u8>())
+                    .collect()
+            } else {
+                (0..num_rows).map(|_| 255).collect()
+            };
+
+            let label = format!(
+                "bn254 g1 packed_msm_benchmark - {} commits, {} rows, {} bit size",
+                num_commits, num_rows, bit_size
+            );
+
+            c.bench_function(&label, |b| {
+                b.iter(|| handle.packed_msm(&mut res, &output_bit_table, &scalars))
+            });
+        }
+    }
+
+    fn curve25519_msm_benchmark(
+        c: &mut Criterion,
+        num_commits: usize,
+        num_rows: usize,
+        bench_runs_bit_size: &[u32],
+    ) {
+        let mut rng = OsRng;
+        let mut res = vec![RistrettoPoint::default(); num_commits];
+
+        let generators: Vec<RistrettoPoint> = (0..num_rows)
+            .map(|_| RistrettoPoint::random(&mut rng))
+            .collect();
+
+        let handle = MsmHandle::new(&generators);
+
+        for &curr_bench_bit_size in bench_runs_bit_size {
+            let bit_size: u32 = curr_bench_bit_size;
+
+            let output_bit_table: Vec<u32> = vec![bit_size; num_rows];
+
+            let scalars: Vec<u8> = if bit_size > 1 {
+                (0..num_rows * bit_size as usize)
+                    .map(|_| rng.gen::<u8>())
+                    .collect()
+            } else {
+                (0..num_rows).map(|_| 255).collect()
+            };
+
+            let label = format!(
+                "curve25519 packed_msm_benchmark - {} commits, {} rows, {} bit size",
+                num_commits, num_rows, bit_size
+            );
+
+            c.bench_function(&label, |b| {
+                b.iter(|| handle.packed_msm(&mut res, &output_bit_table, &scalars))
+            });
+        }
+    }
+
+    fn packed_msm_commitment_computation(c: &mut Criterion) {
+        init_backend();
+
+        let num_commits = 1024;
+        let num_rows = 1024;
+        let bench_runs_bit_size = vec![256, 128, 64, 32, 16, 8, 1];
+
+        bls12_381_msm_benchmark(c, num_commits, num_rows, &bench_runs_bit_size);
+        bn254_msm_benchmark(c, num_commits, num_rows, &bench_runs_bit_size);
+        curve25519_msm_benchmark(c, num_commits, num_rows, &bench_runs_bit_size);
     }
 
     criterion_group! {


### PR DESCRIPTION
# Rationale for this change
There are only Criterion benchmarks for performing msms with `curve25519` curve points. This PR adds benchmarks for more of the curves supported in `blitzar`.

# What changes are included in this PR?
- `blitzar_benchmarks` is renamed `blitzar_curve25519_benchmarks`
- msm benchmarks are added for the `bls12-381 G1`, `bn254 G1`, and `Grumpkin` curves
- `packed_msm_benchmarks` now also benchmarks `bls12-381 G1` and `bn254 G1` curves
- docs are updated

# Are these changes tested?
Yes