### PR TITLE
feat: add halo2curves bn256 scalar element to sequence conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ opentelemetry-jaeger = { version = "0.20.0" }
 rayon = { version = "1.5" }
 blitzar-sys = { version = "1.81.0" }
 curve25519-dalek = { version = "4", features = ["serde"] }
+halo2curves = { version = "0.8.0" }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -190,12 +190,11 @@ impl_dense_sequence_for_unsigned_array!(bool, u8, u16, u32, u64, u128);
 
 impl<'a> From<&'a [halo2curves::bn256::Fr]> for Sequence<'a> {
     fn from(other: &'a [halo2curves::bn256::Fr]) -> Self {
-        let data_slice: &'static [u8] = Box::leak(
+        let data_slice: &[u8] = Box::leak(
             other
                 .iter()
                 .flat_map(|fr| fr.to_bytes())
-                .collect::<Vec<u8>>()
-                .into_boxed_slice(),
+                .collect::<Box<[u8]>>(),
         );
         let element_size = std::mem::size_of::<halo2curves::bn256::Fr>();
         let is_signed = false;

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -188,6 +188,26 @@ macro_rules! impl_dense_sequence_for_unsigned_array {
 }
 impl_dense_sequence_for_unsigned_array!(bool, u8, u16, u32, u64, u128);
 
+impl<'a> From<&'a [halo2curves::bn256::Fr]> for Sequence<'a> {
+    fn from(other: &'a [halo2curves::bn256::Fr]) -> Self {
+        let data_slice: &'static [u8] = Box::leak(
+            other
+                .iter()
+                .flat_map(|fr| fr.to_bytes())
+                .collect::<Vec<u8>>()
+                .into_boxed_slice(),
+        );
+        let element_size = std::mem::size_of::<halo2curves::bn256::Fr>();
+        let is_signed = false;
+
+        Sequence {
+            data_slice,
+            element_size,
+            is_signed,
+        }
+    }
+}
+
 #[cfg(feature = "arkworks")]
 impl<'a, const N: usize> From<&'a [ark_ff::BigInt<N>]> for Sequence<'a> {
     fn from(other: &'a [ark_ff::BigInt<N>]) -> Self {

--- a/src/sequence/test.rs
+++ b/src/sequence/test.rs
@@ -1,5 +1,6 @@
 use super::Sequence;
 use curve25519_dalek::scalar::Scalar;
+use halo2curves::bn256::Fr as Halo2Bn256Fr;
 
 #[test]
 fn we_can_convert_an_empty_slice_of_uints_to_a_sequence() {
@@ -21,6 +22,13 @@ fn we_can_convert_an_empty_slice_of_scalars_to_a_sequence() {
     let s = Vec::<Scalar>::new();
     let d = Sequence::from(&s[..]);
     assert_eq!(d.element_size, std::mem::size_of::<Scalar>());
+    assert!(d.is_empty());
+}
+#[test]
+fn we_can_convert_an_empty_slice_of_halo2_bn256_scalars_to_a_sequence() {
+    let s = Vec::<Halo2Bn256Fr>::new();
+    let d = Sequence::from(&s[..]);
+    assert_eq!(d.element_size, std::mem::size_of::<Halo2Bn256Fr>());
     assert!(d.is_empty());
 }
 #[test]
@@ -187,6 +195,31 @@ fn we_can_convert_a_slice_of_scalars_to_a_sequence_with_correct_data() {
     assert_eq!(
         d.data_slice[2 * d.element_size..3 * d.element_size],
         Scalar::from(789u32).as_bytes()[..]
+    );
+}
+
+#[test]
+fn we_can_convert_a_slice_of_halo2_bn256_scalars_to_a_sequence_with_correct_data() {
+    let s = [
+        Halo2Bn256Fr::from(123u64),
+        -Halo2Bn256Fr::from(456u64),
+        Halo2Bn256Fr::from(789u64),
+    ];
+    let d = Sequence::from(&s[..]);
+    assert_eq!(d.element_size, std::mem::size_of::<Halo2Bn256Fr>());
+    assert_eq!(d.len(), 3);
+
+    assert_eq!(
+        d.data_slice[0..d.element_size],
+        Halo2Bn256Fr::from(123u64).to_bytes()
+    );
+    assert_eq!(
+        d.data_slice[d.element_size..2 * d.element_size],
+        (-Halo2Bn256Fr::from(456u64)).to_bytes()[..]
+    );
+    assert_eq!(
+        d.data_slice[2 * d.element_size..3 * d.element_size],
+        Halo2Bn256Fr::from(789u64).to_bytes()[..]
     );
 }
 


### PR DESCRIPTION
# Rationale for this change
This work supports the GPU acceleration of the hyperkzg commitment scheme found in the [Microsoft/Nova](https://github.com/microsoft/Nova) project. Nova uses halo2curves for points and operations, but this project only supports Arkworks. This is the first step in creating a commitment computation that accepts halo2curve bn256 points.

This work was originally part of PR https://github.com/spaceandtimelabs/blitzar-rs/pull/53.

Note: [Halo2's bn256](https://github.com/privacy-scaling-explorations/halo2curves/tree/3bfa6562f0ddcbac941091ba3c7c9b6c322efac1/src/bn256) is equivalent to [Arkwork's bn254](https://github.com/arkworks-rs/algebra/tree/9ce33e6ef1368a0f5b01b91e6df5bc5877129f30/curves/bn254). Halo2 refers the the number of bits used for each element where Arkwork refers to the number of bits in the prime associated to the base field.

# What changes are included in this PR?
- Adds the `halo2curves` crate to the project
- Implements a conversion from a `halo2curves::bn256::Fr` to `Sequence` in the sequence module
- Adds tests to the sequence module

# Are these changes tested?
Yes
