### PR TITLE
feat: roll back rust edition upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0" # This version will be automatically updated
 readme = "README.md"
 name = "blitzar"
-edition = "2024"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/spaceandtimelabs/blitzar-rs"
 keywords = ["gpu-cryptography", "curve25519", "ristretto255", "bls12-381", "bn254"]

--- a/benches/blitzar_bls12_381_benchmarks.rs
+++ b/benches/blitzar_bls12_381_benchmarks.rs
@@ -15,7 +15,7 @@
 use ark_bls12_381::{Fr, G1Affine};
 use ark_ff::BigInt;
 use ark_std::UniformRand;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate rand;
 use crate::rand::Rng;

--- a/benches/blitzar_bn254_benchmarks.rs
+++ b/benches/blitzar_bn254_benchmarks.rs
@@ -15,7 +15,7 @@
 use ark_bn254::{Fr, G1Affine};
 use ark_ff::BigInt;
 use ark_std::UniformRand;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate rand;
 use crate::rand::Rng;

--- a/benches/blitzar_curve25519_benchmarks.rs
+++ b/benches/blitzar_curve25519_benchmarks.rs
@@ -16,7 +16,7 @@ extern crate rand;
 
 use crate::rand::Rng;
 use blitzar::{compute::*, sequence::Sequence};
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 use curve25519_dalek::{
     constants,
     ristretto::{CompressedRistretto, RistrettoPoint},

--- a/benches/blitzar_grumpkin_benchmarks.rs
+++ b/benches/blitzar_grumpkin_benchmarks.rs
@@ -15,7 +15,7 @@
 use ark_ff::BigInt;
 use ark_grumpkin::{Affine, Fr};
 use ark_std::UniformRand;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate rand;
 use crate::rand::Rng;

--- a/benches/jaeger_benches.rs
+++ b/benches/jaeger_benches.rs
@@ -189,7 +189,7 @@ fn run_benchmark(benchmark_type: &str) {
 }
 
 fn main() {
-    use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
     let tracer = opentelemetry_jaeger::new_agent_pipeline()
         .with_service_name("benches")

--- a/benches/packed_msm_benchmarks.rs
+++ b/benches/packed_msm_benchmarks.rs
@@ -19,7 +19,7 @@ use ark_bls12_381::G1Affine as Bls12381G1Affine;
 use ark_bn254::G1Affine as Bn254G1Affine;
 use ark_std::UniformRand;
 use blitzar::compute::*;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use rand_core::OsRng;
 

--- a/src/compute/commitments_tests.rs
+++ b/src/compute/commitments_tests.rs
@@ -137,11 +137,9 @@ fn we_can_update_multiple_commitments() {
     // verify if commitment results are correct
     assert_eq!(commitments, expected_commitments);
     // If the two vectors are equal we only need to verify that one doesn't contain the default
-    assert!(
-        commitments
-            .iter()
-            .all(|&c| c != CompressedRistretto::default())
-    );
+    assert!(commitments
+        .iter()
+        .all(|&c| c != CompressedRistretto::default()));
 }
 
 #[test]

--- a/src/compute/fixed_msm.rs
+++ b/src/compute/fixed_msm.rs
@@ -1,5 +1,5 @@
 use super::backend::init_backend;
-use crate::compute::{CurveId, ElementP2, curve::SwCurveConfig};
+use crate::compute::{curve::SwCurveConfig, CurveId, ElementP2};
 use ark_ec::short_weierstrass::Affine;
 use rayon::prelude::*;
 use std::{ffi::CString, marker::PhantomData};

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -15,7 +15,7 @@
 //! commitment and generator computation
 
 mod backend;
-pub use backend::{BackendConfig, init_backend, init_backend_with_config};
+pub use backend::{init_backend, init_backend_with_config, BackendConfig};
 
 mod curve;
 use curve::CurveId;

--- a/src/proof/inner_product_tests.rs
+++ b/src/proof/inner_product_tests.rs
@@ -49,11 +49,9 @@ fn test_prove_and_verify_with_given_n_and_generators_offset(n: u64, generators_o
     // We can verify a proof using a valid input data
     {
         let mut transcript = Transcript::new(b"innerproducttest");
-        assert!(
-            proof
-                .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
-                .is_ok()
-        );
+        assert!(proof
+            .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
+            .is_ok());
     }
 
     // We cannot verify a proof using an invalid transcript
@@ -61,11 +59,9 @@ fn test_prove_and_verify_with_given_n_and_generators_offset(n: u64, generators_o
         // we only use the transcript with arrays containing at least one element
         if n > 1 {
             let mut transcript = Transcript::new(b"invalid");
-            assert!(
-                proof
-                    .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
-                    .is_err()
-            );
+            assert!(proof
+                .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
+                .is_err());
         }
     }
 
@@ -73,54 +69,46 @@ fn test_prove_and_verify_with_given_n_and_generators_offset(n: u64, generators_o
     {
         let mut transcript = Transcript::new(b"innerproducttest");
         let a_commit_p = Scalar::from(123_u64) * g[0];
-        assert!(
-            proof
-                .verify(
-                    &mut transcript,
-                    &a_commit_p,
-                    &product,
-                    &b,
-                    generators_offset
-                )
-                .is_err()
-        );
+        assert!(proof
+            .verify(
+                &mut transcript,
+                &a_commit_p,
+                &product,
+                &b,
+                generators_offset
+            )
+            .is_err());
     }
 
     // We cannot verify a proof using an invalid product
     {
         let mut transcript = Transcript::new(b"innerproducttest");
         let product_p = product + Scalar::from(123_u64);
-        assert!(
-            proof
-                .verify(
-                    &mut transcript,
-                    &a_commit,
-                    &product_p,
-                    &b,
-                    generators_offset
-                )
-                .is_err()
-        );
+        assert!(proof
+            .verify(
+                &mut transcript,
+                &a_commit,
+                &product_p,
+                &b,
+                generators_offset
+            )
+            .is_err());
     }
 
     // We cannot verify a proof using an invalid b
     {
         let mut transcript = Transcript::new(b"innerproducttest");
-        assert!(
-            proof
-                .verify(&mut transcript, &a_commit, &product, &a, generators_offset)
-                .is_err()
-        );
+        assert!(proof
+            .verify(&mut transcript, &a_commit, &product, &a, generators_offset)
+            .is_err());
     }
 
     // We can verify the transcript compatibility
     {
         let mut transcript = Transcript::new(b"innerproducttest");
-        assert!(
-            proof
-                .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
-                .is_ok()
-        );
+        assert!(proof
+            .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
+            .is_ok());
 
         // Initialize transcript
         let mut expected_transcript = Transcript::new(b"innerproducttest");
@@ -164,11 +152,9 @@ fn test_prove_and_verify_with_given_n_and_generators_offset(n: u64, generators_o
             let mut tampered_proof = proof;
             tampered_proof.l_vector = Vec::new();
 
-            assert!(
-                tampered_proof
-                    .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
-                    .is_err()
-            );
+            assert!(tampered_proof
+                .verify(&mut transcript, &a_commit, &product, &b, generators_offset)
+                .is_err());
         }
     }
 }


### PR DESCRIPTION
# Rationale for this change
PR https://github.com/spaceandtimelabs/blitzar-rs/pull/60 upgrade the Rust edition to 2024. This has some unintended consequences with other projects. We have elected to hold off on the upgrade at the moment. Some formatting improvements from PR https://github.com/spaceandtimelabs/blitzar-rs/pull/60 remain.

# What changes are included in this PR?
- Rust edition is rolled back to `2021`
- `cargo fmt` changes are added

# Are these changes tested?
Yes
