### PR TITLE
chore: remove extern crate syntax

### DIFF
--- a/benches/blitzar_bls12_381_benchmarks.rs
+++ b/benches/blitzar_bls12_381_benchmarks.rs
@@ -15,11 +15,9 @@
 use ark_bls12_381::{Fr, G1Affine};
 use ark_ff::BigInt;
 use ark_std::UniformRand;
-use criterion::{criterion_group, criterion_main, Criterion};
-
-extern crate rand;
-use crate::rand::Rng;
 use blitzar::{compute::*, sequence::*};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::Rng;
 
 mod blitzar_bls12_381_benchmarks {
     use super::*;

--- a/benches/blitzar_bn254_benchmarks.rs
+++ b/benches/blitzar_bn254_benchmarks.rs
@@ -15,11 +15,9 @@
 use ark_bn254::{Fr, G1Affine};
 use ark_ff::BigInt;
 use ark_std::UniformRand;
-use criterion::{criterion_group, criterion_main, Criterion};
-
-extern crate rand;
-use crate::rand::Rng;
 use blitzar::{compute::*, sequence::*};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::Rng;
 
 mod blitzar_bn254_benchmarks {
     use super::*;

--- a/benches/blitzar_curve25519_benchmarks.rs
+++ b/benches/blitzar_curve25519_benchmarks.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate rand;
-
-use crate::rand::Rng;
 use blitzar::{compute::*, sequence::Sequence};
 use criterion::{criterion_group, criterion_main, Criterion};
 use curve25519_dalek::{
@@ -22,7 +19,7 @@ use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
 };
-use rand::thread_rng;
+use rand::{thread_rng, Rng};
 
 mod blitzar_curve25519_benchmarks {
     use super::*;

--- a/benches/blitzar_grumpkin_benchmarks.rs
+++ b/benches/blitzar_grumpkin_benchmarks.rs
@@ -15,11 +15,9 @@
 use ark_ff::BigInt;
 use ark_grumpkin::{Affine, Fr};
 use ark_std::UniformRand;
-use criterion::{criterion_group, criterion_main, Criterion};
-
-extern crate rand;
-use crate::rand::Rng;
 use blitzar::{compute::*, sequence::*};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::Rng;
 
 mod blitzar_grumpkin_benchmarks {
     use super::*;

--- a/benches/jaeger_benches.rs
+++ b/benches/jaeger_benches.rs
@@ -21,7 +21,6 @@
 //! ```
 //! Then, navigate to <http://localhost:16686> to view the traces.
 
-extern crate blitzar;
 use ark_bls12_381::G1Affine as Bls12381G1Affine;
 use ark_bn254::G1Affine as Bn254G1Affine;
 use ark_grumpkin::Affine as GrumpkinAffine;

--- a/benches/packed_msm_benchmarks.rs
+++ b/benches/packed_msm_benchmarks.rs
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate rand;
-
-use crate::rand::Rng;
 use ark_bls12_381::G1Affine as Bls12381G1Affine;
 use ark_bn254::G1Affine as Bn254G1Affine;
 use ark_std::UniformRand;
 use blitzar::compute::*;
 use criterion::{criterion_group, criterion_main, Criterion};
 use curve25519_dalek::ristretto::RistrettoPoint;
+use rand::Rng;
 use rand_core::OsRng;
 
 mod packed_msm_benches {

--- a/examples/add_mult_commitments.rs
+++ b/examples/add_mult_commitments.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 use curve25519_dalek::scalar::Scalar;

--- a/examples/get_generators.rs
+++ b/examples/get_generators.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};

--- a/examples/get_one_commit.rs
+++ b/examples/get_one_commit.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};

--- a/examples/initialize_backend.rs
+++ b/examples/initialize_backend.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 

--- a/examples/initialize_backend_with_config.rs
+++ b/examples/initialize_backend_with_config.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 use curve25519_dalek::ristretto::CompressedRistretto;

--- a/examples/pass_bls12_381_g1_generators_to_commitment.rs
+++ b/examples/pass_bls12_381_g1_generators_to_commitment.rs
@@ -15,8 +15,6 @@ use ark_bls12_381::{Fr, G1Affine, G1Projective};
 use ark_ec::VariableBaseMSM;
 use ark_serialize::CanonicalSerialize;
 use ark_std::UniformRand;
-
-extern crate blitzar;
 use blitzar::compute::*;
 
 fn main() {

--- a/examples/pass_bn254_g1_generators_to_commitment.rs
+++ b/examples/pass_bn254_g1_generators_to_commitment.rs
@@ -14,8 +14,6 @@
 use ark_bn254::{Fr, G1Affine, G1Projective};
 use ark_ec::{CurveGroup, VariableBaseMSM};
 use ark_std::UniformRand;
-
-extern crate blitzar;
 use blitzar::compute::*;
 
 fn main() {

--- a/examples/pass_curve25519_generators_to_commitment.rs
+++ b/examples/pass_curve25519_generators_to_commitment.rs
@@ -11,12 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
-
 use blitzar::compute::*;
-
-extern crate rand_core;
 use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,

--- a/examples/pass_generators_and_scalars_to_commitment.rs
+++ b/examples/pass_generators_and_scalars_to_commitment.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
-extern crate rand_core;
 
 use blitzar::compute::*;
 use curve25519_dalek::{

--- a/examples/pass_grumpkin_generators_to_commitment.rs
+++ b/examples/pass_grumpkin_generators_to_commitment.rs
@@ -14,8 +14,6 @@
 use ark_ec::{CurveGroup, VariableBaseMSM};
 use ark_grumpkin::{Affine, Fr, Projective};
 use ark_std::UniformRand;
-
-extern crate blitzar;
 use blitzar::compute::*;
 
 fn main() {

--- a/examples/simple_commitment.rs
+++ b/examples/simple_commitment.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};

--- a/examples/simple_fixed_msm.rs
+++ b/examples/simple_fixed_msm.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
-
 use blitzar::compute::*;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use rand_core::OsRng;

--- a/examples/simple_scalars_commitment.rs
+++ b/examples/simple_scalars_commitment.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};

--- a/examples/simple_update_commitment.rs
+++ b/examples/simple_update_commitment.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate blitzar;
-extern crate curve25519_dalek;
 
 use blitzar::compute::*;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,6 @@
 //!
 //! Import the necessary modules to your rust code:
 //! ```text
-//! extern crate blitzar;
-//!
 //! use blitzar::sequence::*;
 //! use blitzar::compute::*;
 //! ```


### PR DESCRIPTION
# Rationale for this change
Since Rust 2018, `extern crate` is no longer needed in `99%` of circumstances, see the [Rust edition guide](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#:~:text=extern%20crate%20is%20no%20longer,crate%20name%2C%20even%20within%20submodules.). This PR removes `extern crate` from the project.

# What changes are included in this PR?
- `extern crate` is removed.

# Are these changes tested?
Yes