### PR TITLE
bench: add benches for halo2curves bn256 commitment computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ name = "blitzar_grumpkin_benchmarks"
 
 [[bench]]
 harness = false
+name = "blitzar_halo2_bn256_benchmarks"
+
+[[bench]]
+harness = false
 name = "jaeger_benches"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -181,8 +181,11 @@ and replace the `benchmark_name` with one of the following available benchmarks
 - `blitzar_bls12_381_benchmarks`
 - `blitzar_bn254_benchmarks`
 - `blitzar_curve25519_benchmarks`
+- `blitzar_halo2_bn256_benchmarks`
 - `blitzar_grumpkin_benchmarks`
 - `packed_msm_benchmarks`
+
+Additionally [Jaeger tracing](https://www.jaegertracing.io/) is supported. For more information on how to run the benchmarks, see the [/benches/jaeger_benches.rs](benches/jaeger_benches.rs) file.
 
 ## Development Process
 

--- a/benches/blitzar_halo2_bn256_benchmarks.rs
+++ b/benches/blitzar_halo2_bn256_benchmarks.rs
@@ -1,0 +1,130 @@
+// Copyright 2023-present Space and Time Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use blitzar::{compute::*, sequence::*};
+use criterion::{criterion_group, criterion_main, Criterion};
+use halo2curves::bn256::{Fr, G1Affine, G1};
+use rand::Rng;
+
+mod blitzar_halo2_bn256_benchmarks {
+    use super::*;
+    use halo2curves::ff::Field;
+
+    fn construct_scalars_data(num_commits: usize, num_rows: usize) -> Vec<Vec<Fr>> {
+        let mut rng = rand::thread_rng();
+
+        (0..num_commits)
+            .map(|_| (0..num_rows).map(|_| Fr::random(&mut rng)).collect())
+            .collect()
+    }
+
+    fn construct_sequences_data(num_commits: usize, num_rows: usize) -> Vec<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+
+        (0..num_commits)
+            .map(|_| ((0..num_rows).map(|_| rng.r#gen::<u8>()).collect()))
+            .collect()
+    }
+
+    fn construct_generators(num_commits: usize) -> Vec<G1Affine> {
+        let mut rng = ark_std::test_rng();
+        (0..num_commits)
+            .map(|_| G1Affine::random(&mut rng))
+            .collect()
+    }
+
+    fn run_computation(num_commits: usize, num_rows: usize, c: &mut Criterion, use_scalars: bool) {
+        let generators = construct_generators(num_rows);
+        let mut commitments = vec![G1::default(); num_commits];
+
+        let benchmark_label: String = "halo2_bn256_g1 ".to_string();
+        let num_commits_label: String = num_commits.to_string() + " commits";
+        let benchmark_group_label: String = benchmark_label + &num_commits_label;
+
+        let with_generators_label: String = num_rows.to_string()
+            + " rows"
+            + " - use scalars ("
+            + if use_scalars { "yes" } else { "no" }
+            + ")";
+
+        let mut group = c.benchmark_group(&benchmark_group_label);
+
+        group.throughput(criterion::Throughput::Elements(
+            (num_commits * num_rows) as u64,
+        ));
+
+        if use_scalars {
+            let data = construct_scalars_data(num_commits, num_rows);
+            let table: Vec<Sequence> = data
+                .iter()
+                .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                .collect();
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_bn254_g1_uncompressed_commitments_with_halo2_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        } else {
+            let data = construct_sequences_data(num_commits, num_rows);
+            let table: Vec<Sequence> = (0..num_commits).map(|i| (&data[i]).into()).collect();
+
+            group.bench_function(&with_generators_label, |b| {
+                b.iter(|| {
+                    compute_bn254_g1_uncompressed_commitments_with_halo2_generators(
+                        &mut commitments,
+                        &table,
+                        &generators,
+                    )
+                })
+            });
+        }
+
+        group.finish();
+    }
+
+    fn batch_commitment_computation_with_scalars(c: &mut Criterion) {
+        init_backend();
+
+        let bench_runs = vec![
+            (1, vec![1, 10, 100, 1000, 10000, 100000]), // 1 commits
+            (10, vec![10, 100, 1000]),                  // 10 commits
+            (100, vec![10, 100, 1000]),                 // 100 commits
+            (1000, vec![10, 100, 1000]),                // 1000 commits
+        ];
+
+        // iterate through the num_commits
+        for curr_bench in bench_runs {
+            // iterate through the num_rows
+            for i in curr_bench.1 {
+                run_computation(curr_bench.0, i, c, false);
+                run_computation(curr_bench.0, i, c, true);
+            }
+        }
+    }
+
+    criterion_group! {
+        name = blitzar_compute_halo2_bn256_g1_commitments;
+        // Lower the sample size to run the benchmarks faster
+        config = Criterion::default().sample_size(15);
+        targets =
+            batch_commitment_computation_with_scalars
+    }
+}
+
+criterion_main!(blitzar_halo2_bn256_benchmarks::blitzar_compute_halo2_bn256_g1_commitments);

--- a/benches/jaeger_benches.rs
+++ b/benches/jaeger_benches.rs
@@ -27,6 +27,7 @@ use ark_grumpkin::Affine as GrumpkinAffine;
 use ark_std::UniformRand;
 use blitzar::sequence::Sequence;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use halo2curves::bn256::{G1Affine as Halo2Bn256G1Affine, G1 as Halo2Bn256G1Projective};
 use rand::Rng;
 use rand_core::OsRng;
 use std::env;
@@ -38,6 +39,7 @@ const BENCHMARK_TYPES: &[&str] = &[
     "compute_curve25519_commitments_with_generators",
     "compute_bls12_381_g1_commitments_with_generators",
     "compute_bn254_g1_uncompressed_commitments_with_generators",
+    "compute_bn254_g1_uncompressed_commitments_with_halo2_generators",
     "compute_grumpkin_uncompressed_commitments_with_generators",
 ];
 
@@ -141,6 +143,41 @@ fn run_benchmark(benchmark_type: &str) {
 
                 for _ in 0..ITERATIONS {
                     blitzar::compute::compute_bn254_g1_uncompressed_commitments_with_generators(
+                        &mut commitments,
+                        &data,
+                        &generators,
+                    );
+                }
+            }
+        }
+        "compute_bn254_g1_uncompressed_commitments_with_halo2_generators" => {
+            for (length, num_outputs) in LENGTH.iter().zip(NUM_OUTPUTS.iter()) {
+                let mut rng = ark_std::test_rng();
+
+                // Generate random data
+                let scalars: Vec<Vec<u64>> = (0..*num_outputs)
+                    .map(|_| {
+                        (0..*length)
+                            .map(|_| rng.gen_range(u64::MIN..u64::MAX))
+                            .collect()
+                    })
+                    .collect();
+
+                let data: Vec<Sequence> = scalars
+                    .iter()
+                    .map(|v| Sequence::from_raw_parts(v.as_slice(), false))
+                    .collect();
+
+                // Generate random generators
+                let generators: Vec<Halo2Bn256G1Affine> = (0..*length)
+                    .map(|_| Halo2Bn256G1Affine::random(&mut rng))
+                    .collect();
+
+                // Create commitments
+                let mut commitments = vec![Halo2Bn256G1Projective::default(); *num_outputs];
+
+                for _ in 0..3 {
+                    blitzar::compute::compute_bn254_g1_uncompressed_commitments_with_halo2_generators(
                         &mut commitments,
                         &data,
                         &generators,


### PR DESCRIPTION
# Rationale for this change
This work adds benchmarks for the `compute_bn254_g1_uncompressed_commitments_with_halo2_generators` function.

This work was originally part of PR https://github.com/spaceandtimelabs/blitzar-rs/pull/53.

# What changes are included in this PR?
- Jaeger tracing is added for `compute_bn254_g1_uncompressed_commitments_with_halo2_generators`
- Criterion benchmarks are added for `compute_bn254_g1_uncompressed_commitments_with_halo2_generators`
- Docs are updated

# Are these changes tested?
Yes
