### PR TITLE
perf: improve ark to halo2 g1 affine point conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ tempfile = "3.13.0"
 
 [[bench]]
 harness = false
+name = "arkworks_halo2_interop_benchmarks"
+
+[[bench]]
+harness = false
 name = "blitzar_bls12_381_benchmarks"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ To run individual tests:
 cargo bench --features <cpu | gpu> --bench <benchmark_name>
 ```
 and replace the `benchmark_name` with one of the following available benchmarks
+- `arkworks_halo2_interop_benchmarks`
 - `blitzar_bls12_381_benchmarks`
 - `blitzar_bn254_benchmarks`
 - `blitzar_curve25519_benchmarks`

--- a/benches/arkworks_halo2_interop_benchmarks.rs
+++ b/benches/arkworks_halo2_interop_benchmarks.rs
@@ -1,0 +1,75 @@
+// Copyright 2025-present Space and Time Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ark_bn254::G1Affine as Bn254G1Affine;
+use blitzar::compute::*;
+use criterion::{criterion_group, criterion_main, Criterion};
+use halo2curves::bn256::G1Affine as Halo2Bn256G1Affine;
+
+mod arkworks_halo2_interop_benchmarks {
+    use super::*;
+    use ark_ff::UniformRand;
+
+    fn benchmark_convert_to_ark_bn254_g1_affine(c: &mut Criterion, num_points: usize) {
+        let mut rnd = rand::thread_rng();
+        let points = (0..num_points)
+            .map(|_| Halo2Bn256G1Affine::random(&mut rnd))
+            .collect::<Vec<Halo2Bn256G1Affine>>();
+
+        c.bench_function(
+            &format!("convert_to_ark_bn254_g1_affine {} points", num_points),
+            |b| {
+                b.iter(|| {
+                    for point in &points {
+                        let _ = convert_to_ark_bn254_g1_affine(point);
+                    }
+                })
+            },
+        );
+    }
+
+    fn benchmark_convert_to_halo2_bn256_g1_affine(c: &mut Criterion, num_points: usize) {
+        let mut rnd = rand::thread_rng();
+        let points = (0..num_points)
+            .map(|_| Bn254G1Affine::rand(&mut rnd))
+            .collect::<Vec<Bn254G1Affine>>();
+
+        c.bench_function(
+            &format!("convert_to_halo2_bn256_g1_affine {} points", num_points),
+            |b| {
+                b.iter(|| {
+                    for point in &points {
+                        let _ = convert_to_halo2_bn256_g1_affine(point);
+                    }
+                })
+            },
+        );
+    }
+
+    fn compute(c: &mut Criterion) {
+        let bench_runs = vec![1024, 8192, 65536, 524288, 1048576, 2097152];
+        for num_points in bench_runs {
+            benchmark_convert_to_ark_bn254_g1_affine(c, num_points);
+            benchmark_convert_to_halo2_bn256_g1_affine(c, num_points);
+        }
+    }
+
+    criterion_group! {
+      name = benchmark_conversion;
+      config = Criterion::default().sample_size(15);
+      targets = compute
+    }
+}
+
+criterion_main!(arkworks_halo2_interop_benchmarks::benchmark_conversion);

--- a/src/compute/arkworks_halo2_interop.rs
+++ b/src/compute/arkworks_halo2_interop.rs
@@ -14,6 +14,7 @@
 
 use ark_bn254::{Fq as Bn254Fq, G1Affine as Bn254G1Affine};
 use ark_ff::BigInteger256;
+use core::mem;
 use halo2curves::{
     bn256::{Fq as Halo2Bn256Fq, G1Affine as Halo2Bn256G1Affine},
     serde::SerdeObject,
@@ -21,11 +22,8 @@ use halo2curves::{
 
 /// Converts a Halo2 BN256 G1 Affine point to an Arkworks BN254 G1 Affine point.
 pub fn convert_to_ark_bn254_g1_affine(point: &Halo2Bn256G1Affine) -> Bn254G1Affine {
-    let x_bytes: [u8; 32] = point.x.to_raw_bytes().try_into().unwrap();
-    let y_bytes: [u8; 32] = point.y.to_raw_bytes().try_into().unwrap();
-
-    let x_limbs = bytemuck::cast::<[u8; 32], [u64; 4]>(x_bytes);
-    let y_limbs = bytemuck::cast::<[u8; 32], [u64; 4]>(y_bytes);
+    let x_limbs: [u64; 4] = unsafe { mem::transmute(point.x) };
+    let y_limbs: [u64; 4] = unsafe { mem::transmute(point.y) };
 
     Bn254G1Affine {
         x: Bn254Fq::new_unchecked(BigInteger256::new(x_limbs)),

--- a/src/compute/arkworks_halo2_interop.rs
+++ b/src/compute/arkworks_halo2_interop.rs
@@ -20,10 +20,15 @@ use halo2curves::{
     serde::SerdeObject,
 };
 
+fn convert_halo2_to_limbs(point: &Halo2Bn256Fq) -> [u64; 4] {
+    let limbs: [u64; 4] = unsafe { mem::transmute(*point) };
+    limbs
+}
+
 /// Converts a Halo2 BN256 G1 Affine point to an Arkworks BN254 G1 Affine point.
 pub fn convert_to_ark_bn254_g1_affine(point: &Halo2Bn256G1Affine) -> Bn254G1Affine {
-    let x_limbs: [u64; 4] = unsafe { mem::transmute(point.x) };
-    let y_limbs: [u64; 4] = unsafe { mem::transmute(point.y) };
+    let x_limbs: [u64; 4] = convert_halo2_to_limbs(&point.x);
+    let y_limbs: [u64; 4] = convert_halo2_to_limbs(&point.y);
 
     Bn254G1Affine {
         x: Bn254Fq::new_unchecked(BigInteger256::new(x_limbs)),
@@ -44,5 +49,40 @@ pub fn convert_to_halo2_bn256_g1_affine(point: &Bn254G1Affine) -> Halo2Bn256G1Af
     Halo2Bn256G1Affine {
         x: Halo2Bn256Fq::from_raw_bytes_unchecked(&x_bytes),
         y: Halo2Bn256Fq::from_raw_bytes_unchecked(&y_bytes),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halo2curves::bn256::Fq as Halo2Bn256Fq;
+
+    #[test]
+    fn test_convert_halo2_modulus_to_limbs() {
+        let expected: [u64; 4] = [
+            4332616871279656263,
+            10917124144477883021,
+            13281191951274694749,
+            3486998266802970665,
+        ];
+        let modulus = Halo2Bn256Fq::from_raw(expected);
+        let point = convert_halo2_to_limbs(&modulus);
+        assert_eq!(point, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_convert_halo2_one_to_one_in_montgomery_form_in_limbs() {
+        let one: [u64; 4] = [1, 0, 0, 0];
+        let one_in_mont = Halo2Bn256Fq::from_raw(one);
+        let point = convert_halo2_to_limbs(&one_in_mont);
+
+        let expected: [u64; 4] = [
+            15230403791020821917,
+            754611498739239741,
+            7381016538464732716,
+            1011752739694698287,
+        ];
+
+        assert_eq!(point, expected);
     }
 }

--- a/src/compute/arkworks_halo2_interop_tests.rs
+++ b/src/compute/arkworks_halo2_interop_tests.rs
@@ -15,6 +15,7 @@
 use super::*;
 use ark_bn254::{Fq as Bn254Fq, G1Affine as Bn254G1Affine};
 use ark_ec::AffineRepr;
+use ark_ff::UniformRand;
 use halo2curves::{
     bn256::{Fq as Halo2Bn256Fq, G1Affine as Halo2Bn256G1Affine},
     group::cofactor::CofactorCurveAffine,
@@ -119,5 +120,35 @@ fn test_convert_ark_bn254_g1_affine_to_halo2_bn256_g1_affine() {
     for (ark, halo2) in ark_affine.iter().zip(expected.iter()) {
         let converted = convert_to_halo2_bn256_g1_affine(ark);
         assert_eq!(converted, *halo2);
+    }
+}
+
+#[test]
+fn test_convert_to_halo2_bn256_g1_affine_with_random_points() {
+    let num_points = 1024;
+    let mut rnd = ark_std::test_rng();
+    let ark_affine = (0..num_points)
+        .map(|_| Bn254G1Affine::rand(&mut rnd))
+        .collect::<Vec<Bn254G1Affine>>();
+
+    for point in &ark_affine {
+        let halo2 = convert_to_halo2_bn256_g1_affine(point);
+        let converted = convert_to_ark_bn254_g1_affine(&halo2);
+        assert_eq!(converted, *point);
+    }
+}
+
+#[test]
+fn test_convert_to_ark_bn254_g1_affine_with_random_points() {
+    let num_points = 1024;
+    let mut rnd = rand::thread_rng();
+    let halo2_affine = (0..num_points)
+        .map(|_| Halo2Bn256G1Affine::random(&mut rnd))
+        .collect::<Vec<Halo2Bn256G1Affine>>();
+
+    for point in &halo2_affine {
+        let ark = convert_to_ark_bn254_g1_affine(point);
+        let converted = convert_to_halo2_bn256_g1_affine(&ark);
+        assert_eq!(converted, *point);
     }
 }


### PR DESCRIPTION
# Rationale for this change
The conversion from Arkworks bn254 g1 affine points to Halo2 bn256 g1 affine points is slow. Benchmarks indicate the performance breakdown of the `convert_to_ark_bn254_g1_affine` function are as follows:

- `.to_raw_bytes().try_into().unwrap()` accounts for 63% of the overall time
- `bytemuck::cast::<[u8; 32], [u64; 4]>(y_bytes)` accounts for the remaining 37% of the overall time
- `Bn254Fq::new_unchecked(BigInteger256::new(limbs))` is statistically negligible

This PR replaces the `to_raw_bytes()` and `bytemuck::cast` with `unsafe { core::mem::transmute() }`. Benchmarks indicate an ~95% improvement of the overall conversion time.

Benchmark results of update with 2,097,152 points 
![image](https://github.com/user-attachments/assets/77c309fb-94cc-48fe-9f6a-f96ef394543c)

Benchmark results of update with 1,048,576 points 
![image](https://github.com/user-attachments/assets/8925e03b-31bf-439d-ad90-7c6d0ebc75c8)

Future work in the Halo2Curves project, [see this PR](https://github.com/privacy-scaling-explorations/halo2curves/pull/190), will allow the `convert_to_halo2_limbs` to be replaced with code that doesn't need to be labeled `unsafe`.

# What changes are included in this PR?
- The `convert_to_ark_bn254_g1_affine` function is updated to call `convert_to_halo2_limbs` which calls `mem::transmute` in this commit https://github.com/spaceandtimelabs/blitzar-rs/pull/68/commits/53842c742621f2fcb26f6483c9402504cff6a16a
- Tests are added for random points in this commit https://github.com/spaceandtimelabs/blitzar-rs/commit/b8df04b6cd155eb69dffa3c94229ce63081c402f
- Criterion benchmarks for the arkworks_halo2_interop module are add in this commit https://github.com/spaceandtimelabs/blitzar-rs/commit/45eae4fe3a21bcb8d9d6a90e9a2772efdcf29a30

# Are these changes tested?
Yes
