### PR TITLE
chore: bump Rust to 1.85.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #
     container:
-      image: rust:1.84
+      image: rust:1.85
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -22,11 +22,14 @@ jobs:
       - name: Checkout Code Format
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
-
-      - name: Install Dependencies
-        run: rustup component add rustfmt
+          
+      - name: Install stable toolchain and dependencies
+        run: |
+          rustup toolchain install 1.85.0
+          rustup default 1.85.0
+          rustup component add rustfmt
 
       - name: Run Code Format
         run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
@@ -41,9 +44,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install Rust
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+
+      - name: Install stable toolchain and dependencies
         run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+          rustup toolchain install 1.85.0
+          rustup default 1.85.0
           rustup component add clippy
 
       - name: Run Clippy
@@ -62,6 +69,11 @@ jobs:
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
 
+      - name: Install stable toolchain
+        run: |
+          rustup toolchain install 1.85.0
+          rustup default 1.85.0
+
       - name: Run CPU test
         run: cargo test --features cpu
 
@@ -77,6 +89,11 @@ jobs:
 
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+
+      - name: Install stable toolchain
+        run: |
+          rustup toolchain install 1.85.0
+          rustup default 1.85.0
 
       - name: Run GPU test
         run: cargo test --features gpu

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -27,8 +27,7 @@ jobs:
           
       - name: Install stable toolchain and dependencies
         run: |
-          rustup toolchain install 1.85.0
-          rustup default 1.85.0
+          rustup toolchain install
           rustup component add rustfmt
 
       - name: Run Code Format
@@ -49,8 +48,7 @@ jobs:
 
       - name: Install stable toolchain and dependencies
         run: |
-          rustup toolchain install 1.85.0
-          rustup default 1.85.0
+          rustup toolchain install
           rustup component add clippy
 
       - name: Run Clippy
@@ -71,8 +69,7 @@ jobs:
 
       - name: Install stable toolchain
         run: |
-          rustup toolchain install 1.85.0
-          rustup default 1.85.0
+          rustup toolchain install
 
       - name: Run CPU test
         run: cargo test --features cpu
@@ -92,8 +89,7 @@ jobs:
 
       - name: Install stable toolchain
         run: |
-          rustup toolchain install 1.85.0
-          rustup default 1.85.0
+          rustup toolchain install
 
       - name: Run GPU test
         run: cargo test --features gpu

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   </a>
 
   <a href="https://www.rust-lang.org/">
-    <img alt="Rust" src="https://img.shields.io/badge/rust-1.84-blue">
+    <img alt="Rust" src="https://img.shields.io/badge/rust-1.85-blue">
     </a>
   </a>
 
@@ -117,7 +117,7 @@ To get a local copy up and running, consider the following steps.
 <details open>
 <summary>GPU backend prerequisites:</summary>
 
-* [Rust 1.84](https://www.rust-lang.org/tools/install)
+* [Rust 1.85](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
 * NVIDIA driver version >= 560.35.03 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
@@ -128,7 +128,7 @@ To get a local copy up and running, consider the following steps.
 
 You'll need the following requirements to run the environment:
 
-* [Rust 1.84](https://www.rust-lang.org/tools/install)
+* [Rust 1.85](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
 
 </details>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!     <img alt="crates.io version" src="https://img.shields.io/crates/v/blitzar.svg">
 //!   </a>
 //!   <a href="https://www.rust-lang.org/">
-//!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.84-blue">
+//!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.85-blue">
 //!  </a>
 //!  <a href="https://developer.nvidia.com/cuda-downloads">
 //!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6.1-green?style=flat&logo=nvidia">


### PR DESCRIPTION
# Rationale for this change
The sxt-proof-of-sql project is updating to Rust version 1.85, see https://github.com/spaceandtimelabs/sxt-proof-of-sql/pull/591. This PR updates the project from Rust 1.84 to 1.85.

# What changes are included in this PR?
- Rust version is bumped to 1.85
- Explicitly install the toolchain inside of CI

# Are these changes tested?
Yes