### PR TITLE
feat!: bump halo2curves to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rayon = { version = "1.5" }
 blitzar-sys = { version = "1.111.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 curve25519-dalek = { version = "4", features = ["serde"] }
-halo2curves = { version = "0.8.0" }
+halo2curves = { version = "0.9.0" }
 merlin = "2"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"


### PR DESCRIPTION
## Summary
- Bump halo2curves dependency from 0.8.0 to 0.9.0

**BREAKING CHANGE:** halo2curves updated from 0.8.0 to 0.9.0

## Test plan
- CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)