### PR TITLE
feat: switch runner to nvidia-nc4as-t4

### DIFF
--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-code:
     name: Check Code
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -35,7 +35,7 @@ jobs:
 
   clippy-code:
     name: Clippy Code
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -56,7 +56,7 @@ jobs:
 
   test-cpu:
     name: Test the CPU backend
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -76,7 +76,7 @@ jobs:
 
   test-gpu:
     name: Test the GPU backend
-    runs-on: self-hosted
+    runs-on: nvidia-nc4as-t4
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       PATH: ${{ github.workspace }}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
## Summary

Switch CI runner from `self-hosted` to `nvidia-nc4as-t4` for all workflow jobs.

## Changes

- Update `runs-on` for `format-code`, `clippy-code`, `test-cpu`, and `test-gpu` jobs to use the `nvidia-nc4as-t4` runner

## Test plan

- CI passes on this PR