### PR TITLE
ci!: remove GH_TOKEN secret dependency from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
     uses: ./.github/workflows/test-check-lint.yml
 
   release:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     name: Build Publish Crate - Linux-x86_64
     runs-on: ubuntu-latest
     needs: [test-check-lint]
@@ -20,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          fetch-depth: 0 # download tags, see https://github.com/actions/checkout/issues/100
 
       - run: git config --global --add safe.directory $(realpath .)
 
@@ -37,5 +41,5 @@ jobs:
           npm install semantic-release
           npx semantic-release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove explicit `token` configuration from `actions/checkout`
- Replace `secrets.GH_TOKEN` with `secrets.GITHUB_TOKEN` for semantic-release
- Add job-level permissions for `GITHUB_TOKEN` (contents, issues, pull-requests write access)
- Add `fetch-depth: 0` to checkout to download tags for semantic-release (see https://github.com/actions/checkout/issues/100)
- Rename `GH_TOKEN` env var to `GITHUB_TOKEN` for consistency

When no token is explicitly set, `actions/checkout` uses `GITHUB_TOKEN` by default as documented at https://github.com/actions/checkout.

## Breaking Change

The `GH_TOKEN` secret is no longer required for the release workflow. The workflow now uses the default `GITHUB_TOKEN` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)