### PR TITLE
build: upgrade blitzar-sys to 1.115.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ark-std = { version = "0.5.0" }
 opentelemetry = { version = "0.23.0" }
 opentelemetry-jaeger = { version = "0.20.0" }
 rayon = { version = "1.5" }
-blitzar-sys = { version = "1.111.0" }
+blitzar-sys = { version = "1.115.3" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 curve25519-dalek = { version = "4", features = ["serde"] }
 halo2curves = { version = "0.9.0" }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6.1-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.8.2-green?style=flat&logo=nvidia">
     </a>
   </a>
 
@@ -119,7 +119,7 @@ To get a local copy up and running, consider the following steps.
 
 * [Rust 1.85](https://www.rust-lang.org/tools/install)
 * `x86_64` Linux instance.
-* NVIDIA driver version >= 560.35.03 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
+* NVIDIA driver version >= 570.211.01 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 
 </details>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!     <img alt="Rust" src="https://img.shields.io/badge/rust-1.85-blue">
 //!  </a>
 //!  <a href="https://developer.nvidia.com/cuda-downloads">
-//!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6.1-green?style=flat&logo=nvidia">
+//!     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.8.2-green?style=flat&logo=nvidia">
 //!  </a>
 //!   <a href="https://github.com/spaceandtimefdn/blitzar-rs">
 //!     <img alt="Build states" src="https://github.com/spaceandtimefdn/blitzar-rs/actions/workflows/release.yml/badge.svg">


### PR DESCRIPTION
# Rationale for this change
This new version of blitzar-sys upgraded to cuda 12.8, increasing the minimum driver version. Technically this version of blitzar-sys can be upgraded to downstream without any changes to blitzar-rs, but this makes it explicit that blitzar-rs versions going forward are associated with these new cuda/driver requirements.

# What changes are included in this PR?
- Upgraded to blitzar-sys 1.115.3
- references to older cuda/driver versions updated

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
